### PR TITLE
changed max line width and count back, removed font replacement

### DIFF
--- a/Wdvh/WhiteTextAbsolute.py
+++ b/Wdvh/WhiteTextAbsolute.py
@@ -15,7 +15,7 @@ class WhiteTextAbsolute(CardType):
 
     """Characteristics for title splitting by this class"""
     TITLE_CHARACTERISTICS = {
-        'max_line_width': 40,   # Character count to begin splitting titles
+        'max_line_width': 32,   # Character count to begin splitting titles
         'max_line_count': 3,    # Maximum number of lines a title can take up
         'top_heavy': False,     # This class uses bottom heavy titling
     }
@@ -151,6 +151,7 @@ class WhiteTextAbsolute(CardType):
         """
 
         return [
+            f'-fill white',
             f'-kerning 5.42',
             f'-pointsize 120',
         ]

--- a/Wdvh/WhiteTextAbsolute.py
+++ b/Wdvh/WhiteTextAbsolute.py
@@ -151,7 +151,6 @@ class WhiteTextAbsolute(CardType):
         """
 
         return [
-            f'-fill white',
             f'-kerning 5.42',
             f'-pointsize 120',
         ]

--- a/Wdvh/WhiteTextTitleOnly.py
+++ b/Wdvh/WhiteTextTitleOnly.py
@@ -14,8 +14,8 @@ class WhiteTextTitleOnly(CardType):
 
     """Characteristics for title splitting by this class"""
     TITLE_CHARACTERISTICS = {
-        'max_line_width': 50,   # Character count to begin splitting titles
-        'max_line_count': 2,    # Maximum number of lines a title can take up
+        'max_line_width': 32,   # Character count to begin splitting titles
+        'max_line_count': 3,    # Maximum number of lines a title can take up
         'top_heavy': False,     # This class uses bottom heavy titling
     }
 
@@ -24,7 +24,7 @@ class WhiteTextTitleOnly(CardType):
     TITLE_COLOR = '#FFFFFF'
 
     """Default characters to replace in the generic font"""
-    FONT_REPLACEMENTS = {':': '\n'}
+    FONT_REPLACEMENTS = {}
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = False


### PR DESCRIPTION
the font replacement changes collided with the title length so much that it was easier to make the necessary changes in the data.yml. The local file doesn't load the sequel font since the ref folder isn't available took me a while to figure out why the font was wrong in the cards. Where should I put the ref folder so it can load the font. 