### PR TITLE
Optionally adjust output card dimensions, PEP8 some docstrings, rewrite `azuravian/TitleColorMatch` to be much faster

### DIFF
--- a/Beedman/GradientLogoTitleCard.py
+++ b/Beedman/GradientLogoTitleCard.py
@@ -420,13 +420,11 @@ class GradientLogoTitleCard(BaseCardType):
         """
 
         command = ' '.join([
-            f'convert',
+            f'composite',
             f'-gravity southwest',
             f'-geometry +50+50',
             f'"{series_count_image.resolve()}"',
             f'"{titled_image.resolve()}"',
-            f'-composite',
-            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Beedman/GradientLogoTitleCard.py
+++ b/Beedman/GradientLogoTitleCard.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from re import findall
+from typing import Optional
 
 from modules.BaseCardType import BaseCardType
 from modules.Debug import log
@@ -8,8 +9,8 @@ from modules.RemoteFile import RemoteFile
 class GradientLogoTitleCard(BaseCardType):
     """
     This class describes a type of CardType created by Beedman, and is 
-    a modification of the StandardTitleCard class with a different gradient 
-    overlay, featuring a logo and left-aligned title text
+    a modification of the StandardTitleCard class with a different
+    gradient  overlay, featuring a logo and left-aligned title text
     """
     
     """Directory where all reference files used by this card are stored"""
@@ -27,15 +28,15 @@ class GradientLogoTitleCard(BaseCardType):
     TITLE_COLOR = '#EBEBEB'
 
     """Default characters to replace in the generic font"""
-    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']', '―': '-',
-                         '…': '...'}
+    FONT_REPLACEMENTS = {
+        '[': '(', ']': ')', '(': '[', ')': ']', '―': '-', '…': '...'
+    }
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = True
 
     """Archive name for this card type"""
     ARCHIVE_NAME = 'Gradient Logo Style'
-
 
     """Source path for the gradient image overlayed over all title cards"""
     __GRADIENT_IMAGE = str(RemoteFile('Beedman', 'leftgradient.png'))
@@ -59,16 +60,26 @@ class GradientLogoTitleCard(BaseCardType):
     )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 season_text: str, episode_text: str, font: str,
-                 font_size: float, title_color: str, hide_season: bool,
-                 blur: bool=False, grayscale: bool=False, vertical_shift: int=0,
-                 interline_spacing: int=0, kerning: float=1.0,
-                 stroke_width: float=1.0, logo: str=None, **kwargs) -> None:
+    def __init__(self, *,
+            source: Path,
+            output_file: Path,
+            title: str,
+            season_text: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            hide_season: bool,
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            logo: Optional[str] = None,
+            **unused) -> None:
         """
-        Initialize the TitleCardMaker object. This primarily just stores
-        instance variables for later use in `create()`. If the provided font
-        does not have a character in the title text, a space is used instead.
+        Construct a new instance of this card.
 
         Args:
             source: Source image.
@@ -79,16 +90,15 @@ class GradientLogoTitleCard(BaseCardType):
             font: Font to use for the episode title.
             font_size: Scalar to apply to the title font size.
             title_color: Color to use for the episode title.
-            hide_season: Whether to omit the season text (and joining character)
-                from the title card completely.
+            hide_season: Whether to omit the season text.
             blur: Whether to blur the source image.
             grayscale: Whether to make the source image grayscale.
             vertical_shift: Pixels to adjust title vertical shift by.
-            interline_spacing: Pixels to adjust title interline spacing by.
+            interline_spacing: Pixels to adjust title interline spacing.
             kerning: Scalar to apply to kerning of the title text.
-            stroke_width: Scalar to apply to black stroke of the title text.
+            stroke_width: Scalar to apply to stroke of the title text.
             logo: Filepath to the logo file.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -118,7 +128,8 @@ class GradientLogoTitleCard(BaseCardType):
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 157.41 * self.font_size
@@ -139,7 +150,8 @@ class GradientLogoTitleCard(BaseCardType):
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 3.0 * self.stroke_width
@@ -156,7 +168,8 @@ class GradientLogoTitleCard(BaseCardType):
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -170,7 +183,8 @@ class GradientLogoTitleCard(BaseCardType):
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -185,7 +199,8 @@ class GradientLogoTitleCard(BaseCardType):
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -198,7 +213,8 @@ class GradientLogoTitleCard(BaseCardType):
         """
         Resize the logo into at most a 1155x650 bounding box.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -217,7 +233,8 @@ class GradientLogoTitleCard(BaseCardType):
         """
         Add the static gradient to this object's source image.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -237,7 +254,8 @@ class GradientLogoTitleCard(BaseCardType):
         """
         Add the resized logo to the same intermediate image as above because that's what worked.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -459,8 +477,8 @@ class GradientLogoTitleCard(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Skip card if logo doesn't exist

--- a/Beedman/GradientLogoTitleCard.py
+++ b/Beedman/GradientLogoTitleCard.py
@@ -297,6 +297,7 @@ class GradientLogoTitleCard(BaseCardType):
             f'-annotate +50+50 "{self.episode_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +50+50 "{self.episode_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -406,6 +407,7 @@ class GradientLogoTitleCard(BaseCardType):
             f'-geometry +50+50',
             f'"{series_count_image.resolve()}"',
             f'"{titled_image.resolve()}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Beedman/GradientLogoTitleCard.py
+++ b/Beedman/GradientLogoTitleCard.py
@@ -420,11 +420,12 @@ class GradientLogoTitleCard(BaseCardType):
         """
 
         command = ' '.join([
-            f'composite',
+            f'convert',
             f'-gravity southwest',
             f'-geometry +50+50',
             f'"{series_count_image.resolve()}"',
             f'"{titled_image.resolve()}"',
+            f'-composite',
             *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])

--- a/CollinHeist/BetterStandardTitleCard.py
+++ b/CollinHeist/BetterStandardTitleCard.py
@@ -8,8 +8,8 @@ from modules.Debug import log
 
 class BetterStandardTitleCard(BaseCardType):
     """
-    This class describes a BETTER version of the StandardTitleCard type, and is
-    primarily for demonstrative purposes.
+    This class describes a BETTER version of the StandardTitleCard type,
+    and is primarily for demonstrative purposes.
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -50,15 +50,23 @@ class BetterStandardTitleCard(BaseCardType):
     )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 season_text: str, episode_text: str, font_size: float,
-                 hide_season: bool, blur: bool=False, grayscale: bool=False,
-                 vertical_shift: int=0, interline_spacing: int=0,
-                 kerning: float=1.0, stroke_width: float=1.0, **kwargs) -> None:
+    def __init__(self, *,
+            source: Path,
+            output_file: Path,
+            title: str,
+            season_text: str,
+            episode_text: str,
+            font_size: float,
+            hide_season: bool,
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            **unused) -> None:
         """
-        Initialize the TitleCardMaker object. This primarily just stores
-        instance variables for later use in `create()`. If the provided font
-        does not have a character in the title text, a space is used instead.
+        Construct a new instance of this card.
 
         Args:
             source: Source image to base the card on.
@@ -77,7 +85,7 @@ class BetterStandardTitleCard(BaseCardType):
             interline_spacing: Pixel count to adjust title interline spacing by.
             kerning: Scalar to apply to kerning of the title text.
             stroke_width: Scalar to apply to black stroke of the title text.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -107,7 +115,8 @@ class BetterStandardTitleCard(BaseCardType):
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 97.41 * self.font_size * (random() + 0.5)
@@ -128,7 +137,8 @@ class BetterStandardTitleCard(BaseCardType):
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 3.0 * self.stroke_width
@@ -145,7 +155,8 @@ class BetterStandardTitleCard(BaseCardType):
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -159,7 +170,8 @@ class BetterStandardTitleCard(BaseCardType):
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -174,7 +186,8 @@ class BetterStandardTitleCard(BaseCardType):
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -188,7 +201,8 @@ class BetterStandardTitleCard(BaseCardType):
         """
         Add the static gradient to this object's source image.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -423,8 +437,8 @@ class BetterStandardTitleCard(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Add the gradient to the source image (always)

--- a/CollinHeist/BetterStandardTitleCard.py
+++ b/CollinHeist/BetterStandardTitleCard.py
@@ -250,6 +250,7 @@ class BetterStandardTitleCard(BaseCardType):
             f'-annotate +0+697.2 "{self.episode_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +0+697.2 "{self.episode_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -359,6 +360,7 @@ class BetterStandardTitleCard(BaseCardType):
             f'-geometry +0+690.2',
             f'"{series_count_image.resolve()}"',
             f'"{titled_image.resolve()}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -430,9 +432,6 @@ class BetterStandardTitleCard(BaseCardType):
 
         # Add either one or two lines of episode text 
         titled_image = self._add_title_text(gradient_image)
-
-        # Create the output directory and any necessary parents 
-        self.output_file.parent.mkdir(parents=True, exist_ok=True)
 
         # If season text is hidden, just add episode text 
         if self.hide_season:

--- a/CollinHeist/StandardAllBoldCard.py
+++ b/CollinHeist/StandardAllBoldCard.py
@@ -198,6 +198,7 @@ class StandardAllBoldCard(BaseCardType):
             f'-stroke "{self.SERIES_COUNT_TEXT_COLOR}"',
             f'-strokewidth 0.75',
             f'-annotate +0+697.2 "{series_count_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/CollinHeist/StandardAllBoldCard.py
+++ b/CollinHeist/StandardAllBoldCard.py
@@ -24,8 +24,9 @@ class StandardAllBoldCard(BaseCardType):
     """Characteristics of the default title font"""
     TITLE_FONT = str((REF_DIRECTORY / 'Sequel-Neue.otf').resolve())
     TITLE_COLOR = '#EBEBEB'
-    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']', '―': '-',
-                         '…': '...'}
+    FONT_REPLACEMENTS = {
+        '[': '(', ']': ')', '(': '[', ')': ']', '―': '-', '…': '...'
+    }
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = True
@@ -40,22 +41,33 @@ class StandardAllBoldCard(BaseCardType):
     """Source path for the gradient image overlayed over all title cards"""
     __GRADIENT_IMAGE = REF_DIRECTORY / 'GRADIENT.png'
 
-    __slots__ = ('source_file', 'output_file', 'title', 'season_text',
-                 'episode_text', 'font', 'font_size', 'title_color',
-                 'hide_season', 'separator', 'blur', 'vertical_shift', 
-                 'interline_spacing', 'kerning', 'stroke_width')
+    __slots__ = (
+        'source_file', 'output_file', 'title', 'season_text', 'episode_text',
+        'font', 'font_size', 'title_color', 'hide_season', 'separator', 'blur',
+        'vertical_shift', 'interline_spacing', 'kerning', 'stroke_width'
+    )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 season_text: str, episode_text: str, font: str,
-                 font_size: float, title_color: str, hide_season: bool,
-                 separator: str='•', blur: bool=False, grayscale: bool=False,
-                 vertical_shift: int=0, interline_spacing: int=0,
-                 kerning: float=1.0, stroke_width: float=1.0, **kwargs) -> None:
+    def __init__(self, *,
+            source: Path,
+            output_file: Path,
+            title: str,
+            season_text: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            hide_season: bool = False,
+            separator: str = '•',
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            **unused) -> None:
         """
-        Initialize the TitleCardMaker object. This primarily just stores
-        instance variables for later use in `create()`. If the provided font
-        does not have a character in the title text, a space is used instead.
+        Construct a new instance of this card.
 
         Args:
             source: Source image to base the card on.
@@ -102,12 +114,14 @@ class StandardAllBoldCard(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determine whether the given font characteristics constitute a default or
-        custom font.
-        
-        :param      font:   The Font being evaluated.
-        
-        :returns:   True if a custom font is indicated, False otherwise.
+        Determines whether the given arguments represent a custom font
+        for this card. This CardType only uses custom font cases.
+
+        Args:
+            font: The Font being evaluated.
+
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != StandardAllBoldCard.TITLE_FONT)
@@ -123,14 +137,15 @@ class StandardAllBoldCard(BaseCardType):
     def is_custom_season_titles(custom_episode_map: bool, 
                                 episode_text_format: str) -> bool:
         """
-        Determine whether the given attributes constitute custom or generic
-        season titles.
-        
-        :param      custom_episode_map:     Whether the EpisodeMap was
-                                            customized.
-        :param      episode_text_format:    The episode text format in use.
-        
-        :returns:   True if custom season titles are indicated, False otherwise.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
+
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
+
+        Returns:
+            True if custom season titles are indicated, False otherwise.
         """
 
         standard_etf = StandardAllBoldCard.EPISODE_TEXT_FORMAT.upper()
@@ -141,8 +156,8 @@ class StandardAllBoldCard(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
 
         font_size = 157.41 * self.font_size

--- a/Wdvh/StarWarsTitleOnly.py
+++ b/Wdvh/StarWarsTitleOnly.py
@@ -51,8 +51,13 @@ class StarWarsTitleOnly (BaseCardType):
     __slots__ = ('source_file', 'output_file', 'title')
 
     
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 blur: bool=False, grayscale: bool=False, **kwargs) -> None:
+    def __init__(self, *,
+            source: Path,
+            output_file: Path,
+            title: str,
+            blur: bool = False,
+            grayscale: bool = False,
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -82,7 +87,8 @@ class StarWarsTitleOnly (BaseCardType):
         
         :param      source: The source image to modify.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -99,11 +105,12 @@ class StarWarsTitleOnly (BaseCardType):
         return self.__SOURCE_WITH_STARS
 
 
-    def __add_title_text(self) -> list:
+    def __add_title_text(self) -> list[str]:
         """
         ImageMagick commands to add the episode title text to an image.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -142,37 +149,42 @@ class StarWarsTitleOnly (BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given arguments represent a custom font for this
-        card. This CardType does not use custom fonts, so this is always False.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   False, as fonts are not customizable with this card.
+        Returns:
+            False, as custom fonts are not used.
         """
 
         return False
 
 
     @staticmethod
-    def is_custom_season_titles(episode_text_format: str,
-                                *args, **kwargs) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      episode_text_format:    The episode text format in use.
-        :param      args and kwargs:        Generic arguments to permit 
-                                            generalized function calls for any
-                                            CardType.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   False, as season titles are not utilized.
+        Returns:
+            False. Custom season titles are not used.
         """
         
         return False
 
 
     def create(self) -> None:
-        """Create the title card as defined by this object."""
+        """
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
+        """
 
         # Add the starry gradient to the source image
         star_image = self.__add_star_gradient(self.source_file)

--- a/Wdvh/StarWarsTitleOnly.py
+++ b/Wdvh/StarWarsTitleOnly.py
@@ -130,6 +130,7 @@ class StarWarsTitleOnly (BaseCardType):
         command = ' '.join([
             f'convert "{gradient_source.resolve()}"',
             *self.__add_title_text(),
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Wdvh/WhiteTextAbsolute.py
+++ b/Wdvh/WhiteTextAbsolute.py
@@ -7,7 +7,8 @@ from modules.RemoteFile import RemoteFile
 
 class WhiteTextAbsolute(BaseCardType):
     """
-    This class describes Wdvh's absolute CardType intended for absolute episode ordering
+    This class describes Wdvh's absolute CardType intended for absolute
+    episode ordering
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -54,11 +55,21 @@ class WhiteTextAbsolute(BaseCardType):
     )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 episode_text: str, font: str, font_size: float,
-                 title_color: str, blur: bool=False, grayscale: bool=False,
-                 vertical_shift: int=0, interline_spacing: int=0,
-                 kerning: float=1.0, stroke_width: float=1.0, **kwargs) -> None:
+    def __init__(self, *,
+            source: Path,
+            output_file: Path,
+            title: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -101,12 +112,13 @@ class WhiteTextAbsolute(BaseCardType):
         self.stroke_width = stroke_width
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 180 * self.font_size
@@ -123,11 +135,12 @@ class WhiteTextAbsolute(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self) -> list:
+    def __title_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 4.0 * self.stroke_width
@@ -139,12 +152,13 @@ class WhiteTextAbsolute(BaseCardType):
         ]
 
 
-    def __series_count_text_global_effects(self) -> list:
+    def __series_count_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -153,12 +167,13 @@ class WhiteTextAbsolute(BaseCardType):
         ]
 
 
-    def __series_count_text_black_stroke(self) -> list:
+    def __series_count_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -168,12 +183,13 @@ class WhiteTextAbsolute(BaseCardType):
         ]
 
 
-    def __series_count_text_effects(self) -> list:
+    def __series_count_text_effects(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -187,7 +203,8 @@ class WhiteTextAbsolute(BaseCardType):
         """
         Add the static gradient to this object's source image.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -261,12 +278,14 @@ class WhiteTextAbsolute(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given font characteristics constitute a default
-        or custom font.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   True if a custom font is indicated, False otherwise.
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != WhiteTextAbsolute.TITLE_FONT)
@@ -280,17 +299,18 @@ class WhiteTextAbsolute(BaseCardType):
 
 
     @staticmethod
-    def is_custom_season_titles(custom_episode_map: bool, 
-                                episode_text_format: str) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      custom_episode_map:     Whether the EpisodeMap was
-                                            customized.
-        :param      episode_text_format:    The episode text format in use.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   True if custom season titles are indicated, False otherwise.
+        Returns:
+            False. Custom season titles are not used.
         """
 
         return False
@@ -298,8 +318,8 @@ class WhiteTextAbsolute(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Add the gradient to the source image (always)

--- a/Wdvh/WhiteTextAbsolute.py
+++ b/Wdvh/WhiteTextAbsolute.py
@@ -249,6 +249,7 @@ class WhiteTextAbsolute(BaseCardType):
             f'-annotate +100-750 "{self.episode_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +100-750 "{self.episode_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -306,9 +307,6 @@ class WhiteTextAbsolute(BaseCardType):
 
         # Add either one or two lines of episode text 
         titled_image = self._add_title_text(gradient_image)
-
-        # Create the output directory and any necessary parents 
-        self.output_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Add episode text 
         self._add_series_count_text_no_season(titled_image)

--- a/Wdvh/WhiteTextAbsoluteLogo.py
+++ b/Wdvh/WhiteTextAbsoluteLogo.py
@@ -289,6 +289,7 @@ class WhiteTextAbsoluteLogo(BaseCardType):
             f'-annotate +100-750 "{self.episode_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +100-750 "{self.episode_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -357,9 +358,6 @@ class WhiteTextAbsoluteLogo(BaseCardType):
 
         # Add either one or two lines of episode text 
         titled_image = self._add_title_text(backdrop_logo)
-
-        # Create the output directory and any necessary parents 
-        self.output_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Add episode text 
         self._add_series_count_text_no_season(titled_image)

--- a/Wdvh/WhiteTextAbsoluteLogo.py
+++ b/Wdvh/WhiteTextAbsoluteLogo.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 from modules.BaseCardType import BaseCardType
 from modules.Debug import log
@@ -6,8 +7,8 @@ from modules.RemoteFile import RemoteFile
 
 class WhiteTextAbsoluteLogo(BaseCardType):
     """
-    This class describes Wdvh's absolute CardType intended for absolute episode
-    ordering.
+    This class describes Wdvh's absolute CardType intended for absolute
+    episode ordering.
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -55,12 +56,22 @@ class WhiteTextAbsoluteLogo(BaseCardType):
     )
 
 
-    def __init__(self, output_file: Path, title: str, episode_text: str,
-                 font: str, font_size: float, title_color: str,
-                 blur: bool=False, grayscale: bool=False, vertical_shift: int=0,
-                 interline_spacing: int=0, kerning: float=1.0,
-                 stroke_width: float=1.0, logo: str=None,
-                 background: str='#000000', **kwargs) -> None:
+    def __init__(self, *,
+            output_file: Path,
+            title: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            logo: Optional[str] = None,
+            background: str = '#000000',
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -78,7 +89,7 @@ class WhiteTextAbsoluteLogo(BaseCardType):
             kerning: Scalar to apply to kerning of the title text.
             stroke_width: Scalar to apply to black stroke of the title text.
             background: Background color of the image.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -107,12 +118,13 @@ class WhiteTextAbsoluteLogo(BaseCardType):
         self.background = background
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 180 * self.font_size
@@ -129,11 +141,12 @@ class WhiteTextAbsoluteLogo(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self) -> list:
+    def __title_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 4.0 * self.stroke_width
@@ -145,12 +158,13 @@ class WhiteTextAbsoluteLogo(BaseCardType):
         ]
 
 
-    def __series_count_text_global_effects(self) -> list:
+    def __series_count_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -159,12 +173,13 @@ class WhiteTextAbsoluteLogo(BaseCardType):
         ]
 
 
-    def __series_count_text_black_stroke(self) -> list:
+    def __series_count_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -174,12 +189,13 @@ class WhiteTextAbsoluteLogo(BaseCardType):
         ]
 
 
-    def __series_count_text_effects(self) -> list:
+    def __series_count_text_effects(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -193,7 +209,8 @@ class WhiteTextAbsoluteLogo(BaseCardType):
         """
         Resize the logo into at most a 1875x1030 bounding box.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -213,7 +230,8 @@ class WhiteTextAbsoluteLogo(BaseCardType):
         """
         Add the resized logo to a fixed color backdrop.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         # Get height of the resized logo to determine offset
@@ -300,13 +318,16 @@ class WhiteTextAbsoluteLogo(BaseCardType):
 
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
+        
         """
-        Determines whether the given font characteristics constitute a default
-        or custom font.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   True if a custom font is indicated, False otherwise.
+        Returns:
+            False, as custom fonts are not used.
         """
 
         return ((font.file != WhiteTextAbsoluteLogo.TITLE_FONT)
@@ -320,17 +341,18 @@ class WhiteTextAbsoluteLogo(BaseCardType):
 
 
     @staticmethod
-    def is_custom_season_titles(custom_episode_map: bool, 
-                                episode_text_format: str) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      custom_episode_map:     Whether the EpisodeMap was
-                                            customized.
-        :param      episode_text_format:    The episode text format in use.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   True if custom season titles are indicated, False otherwise.
+        Returns:
+            False. Custom season titles are not used.
         """
 
         return False
@@ -338,8 +360,8 @@ class WhiteTextAbsoluteLogo(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Skip card if logo doesn't exist

--- a/Wdvh/WhiteTextAbsoluteLogo.py
+++ b/Wdvh/WhiteTextAbsoluteLogo.py
@@ -318,7 +318,6 @@ class WhiteTextAbsoluteLogo(BaseCardType):
 
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
-        
         """
         Determines whether the given font characteristics constitute a
         default or custom font.

--- a/Wdvh/WhiteTextStandard.py
+++ b/Wdvh/WhiteTextStandard.py
@@ -5,10 +5,7 @@ from modules.RemoteFile import RemoteFile
 
 class WhiteTextStandard(BaseCardType):
     """
-    This class describes a type of CardType that produces the 'generic' title
-    cards based on Reddit user /u/UniversalPolymath. This card supports 
-    customization of every aspect of the card, but does not use any arbitrary
-    data.
+    WDVH's WhiteTextStandard card type.
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -53,12 +50,24 @@ class WhiteTextStandard(BaseCardType):
     )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 season_text: str, episode_text: str, font: str,
-                 font_size: float, title_color: str, hide_season: bool,
-                 separator: str='-', blur: bool=False, grayscale: bool=False,
-                 vertical_shift: int=0, interline_spacing: int=0,
-                 kerning: float=1.0, stroke_width: float=1.0, **kwargs) -> None:
+    def __init__(self,
+            source: Path,
+            output_file: Path,
+            title: str,
+            season_text: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            hide_season: bool = False,
+            separator: str = '-',
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -79,7 +88,7 @@ class WhiteTextStandard(BaseCardType):
             interline_spacing: Pixel count to adjust title interline spacing by.
             kerning: Scalar to apply to kerning of the title text.
             stroke_width: Scalar to apply to black stroke of the title text.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -104,12 +113,13 @@ class WhiteTextStandard(BaseCardType):
         self.stroke_width = stroke_width
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 180 * self.font_size
@@ -126,11 +136,12 @@ class WhiteTextStandard(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self) -> list:
+    def __title_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 4.0 * self.stroke_width
@@ -142,12 +153,13 @@ class WhiteTextStandard(BaseCardType):
         ]
 
 
-    def __series_count_text_global_effects(self) -> list:
+    def __series_count_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -156,12 +168,13 @@ class WhiteTextStandard(BaseCardType):
         ]
 
 
-    def __series_count_text_black_stroke(self) -> list:
+    def __series_count_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -171,12 +184,13 @@ class WhiteTextStandard(BaseCardType):
         ]
 
 
-    def __series_count_text_effects(self) -> list:
+    def __series_count_text_effects(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -190,7 +204,8 @@ class WhiteTextStandard(BaseCardType):
         """
         Add the static gradient to this object's source image.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -270,12 +285,14 @@ class WhiteTextStandard(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given font characteristics constitute a default
-        or custom font.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   True if a custom font is indicated, False otherwise.
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != WhiteTextStandard.TITLE_FONT)
@@ -289,23 +306,24 @@ class WhiteTextStandard(BaseCardType):
 
 
     @staticmethod
-    def is_custom_season_titles(custom_episode_map: bool, 
-                                episode_text_format: str) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      custom_episode_map:     Whether the EpisodeMap was
-                                            customized.
-        :param      episode_text_format:    The episode text format in use.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   True if custom season titles are indicated, False otherwise.
+        Returns:
+            True if custom season title are indicated. False otherwise.
         """
 
         standard_etf = WhiteTextStandard.EPISODE_TEXT_FORMAT.upper()
 
-        return (custom_episode_map or
-                episode_text_format.upper() != standard_etf)
+        return (custom_episode_map
+                or episode_text_format.upper() != standard_etf)
 
 
     def create(self) -> None:

--- a/Wdvh/WhiteTextStandard.py
+++ b/Wdvh/WhiteTextStandard.py
@@ -258,6 +258,7 @@ class WhiteTextStandard(BaseCardType):
             f'-annotate +0+800 "{series_count_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +0+800 "{series_count_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Wdvh/WhiteTextStandardLogo.py
+++ b/Wdvh/WhiteTextStandardLogo.py
@@ -302,6 +302,7 @@ class WhiteTextStandardLogo(BaseCardType):
             f'-annotate +0+697.2 "{self.episode_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +0+697.2 "{self.episode_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -411,6 +412,7 @@ class WhiteTextStandardLogo(BaseCardType):
             f'-geometry +0+690.2',
             f'"{series_count_image.resolve()}"',
             f'"{titled_image.resolve()}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Wdvh/WhiteTextStandardLogo.py
+++ b/Wdvh/WhiteTextStandardLogo.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from re import findall
+from typing import Optional
 
 from modules.BaseCardType import BaseCardType
 from modules.RemoteFile import RemoteFile
@@ -7,6 +8,7 @@ from modules.Debug import log
 
 class WhiteTextStandardLogo(BaseCardType):
     """
+    WDVH's WhiteTextStandardLogo card type.
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -53,14 +55,26 @@ class WhiteTextStandardLogo(BaseCardType):
     )
 
 
-    def __init__(self, output_file: Path, title: str, season_text: str,
-                 episode_text: str, font: str, font_size: float,
-                 title_color: str, hide_season: bool, season_number: int=1,
-                 episode_number: int=1, separator: str='-', blur: bool=False,
-                 grayscale: bool=False, vertical_shift: int=0,
-                 kerning: float=1.0, interline_spacing: int=0,
-                 stroke_width: float=1.0, logo: str=None, 
-                 background: str='#000000', **kwargs) -> None:
+    def __init__(self,
+            output_file: Path,
+            title: str,
+            season_text: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            hide_season: bool,
+            season_number: int = 1,
+            episode_number: int = 1,
+            separator: str = '-',
+            blur: bool=False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            kerning: float = 1.0,
+            interline_spacing: int = 0,
+            stroke_width: float = 1.0,
+            logo: Optional[str] = None, 
+            background: str = '#000000', **kwargs) -> None:
         """
         Initialize this CardType object.
 
@@ -120,12 +134,13 @@ class WhiteTextStandardLogo(BaseCardType):
         self.separator = separator
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 180 * self.font_size
@@ -142,11 +157,12 @@ class WhiteTextStandardLogo(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self) -> list:
+    def __title_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 4.0 * self.stroke_width
@@ -158,12 +174,13 @@ class WhiteTextStandardLogo(BaseCardType):
         ]
 
 
-    def __series_count_text_global_effects(self) -> list:
+    def __series_count_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -172,12 +189,13 @@ class WhiteTextStandardLogo(BaseCardType):
         ]
 
 
-    def __series_count_text_black_stroke(self) -> list:
+    def __series_count_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -187,12 +205,13 @@ class WhiteTextStandardLogo(BaseCardType):
         ]
 
 
-    def __series_count_text_effects(self) -> list:
+    def __series_count_text_effects(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -206,7 +225,8 @@ class WhiteTextStandardLogo(BaseCardType):
         """
         Resize the logo into at most a 1875x1030 bounding box.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -226,7 +246,8 @@ class WhiteTextStandardLogo(BaseCardType):
         """
         Add the resized logo to a fixed color backdrop.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         # Get height of the resized logo to determine offset
@@ -354,8 +375,8 @@ class WhiteTextStandardLogo(BaseCardType):
         }
 
 
-    def _create_series_count_text_image(self, width: float, width1: float,
-                                        width2: float, height: float) -> Path:
+    def _create_series_count_text_image(self,
+            width: float, width1: float, width2: float, height: float) -> Path:
         """
         Creates an image with only series count text. This image is transparent,
         and not any wider than is necessary (as indicated by `dimensions`).
@@ -424,12 +445,14 @@ class WhiteTextStandardLogo(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given font characteristics constitute a default
-        or custom font.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   True if a custom font is indicated, False otherwise.
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != WhiteTextStandardLogo.TITLE_FONT)
@@ -443,17 +466,18 @@ class WhiteTextStandardLogo(BaseCardType):
 
 
     @staticmethod
-    def is_custom_season_titles(custom_episode_map: bool, 
-                                episode_text_format: str) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      custom_episode_map:     Whether the EpisodeMap was
-                                            customized.
-        :param      episode_text_format:    The episode text format in use.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   True if custom season titles are indicated, False otherwise.
+        Returns:
+            True if custom season title are indicated. False otherwise.
         """
 
         standard_etf = WhiteTextStandardLogo.EPISODE_TEXT_FORMAT.upper()
@@ -464,8 +488,8 @@ class WhiteTextStandardLogo(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Skip card if logo doesn't exist

--- a/Wdvh/WhiteTextTitleOnly.py
+++ b/Wdvh/WhiteTextTitleOnly.py
@@ -165,6 +165,7 @@ class WhiteTextTitleOnly(BaseCardType):
             f'-annotate +0+{vertical_shift} "{self.title}"',
             f'-fill "{self.title_color}"',
             f'-annotate +0+{vertical_shift} "{self.title}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Wdvh/WhiteTextTitleOnly.py
+++ b/Wdvh/WhiteTextTitleOnly.py
@@ -6,7 +6,7 @@ from modules.RemoteFile import RemoteFile
 
 class WhiteTextTitleOnly(BaseCardType):
     """
-    This class describes Wdvh's title only title CardType
+    This class describes Wdvh's title only title CardType.
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -45,11 +45,20 @@ class WhiteTextTitleOnly(BaseCardType):
     )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str, font: str,
-                 font_size: float, title_color: str, blur: bool=False,
-                 grayscale: bool=False, vertical_shift: int=0,
-                 interline_spacing: int=0, kerning: float=1.0,
-                 stroke_width: float=1.0, **kwargs) -> None:
+    def __init__(self,
+            source: Path,
+            output_file: Path,
+            title: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -66,7 +75,7 @@ class WhiteTextTitleOnly(BaseCardType):
             interline_spacing: Pixel count to adjust title interline spacing by.
             kerning: Scalar to apply to kerning of the title text.
             stroke_width: Scalar to apply to black stroke of the title text.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -87,12 +96,13 @@ class WhiteTextTitleOnly(BaseCardType):
         self.stroke_width = stroke_width
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 180 * self.font_size
@@ -109,11 +119,12 @@ class WhiteTextTitleOnly(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self) -> list:
+    def __title_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 4.0 * self.stroke_width
@@ -129,7 +140,8 @@ class WhiteTextTitleOnly(BaseCardType):
         """
         Add the static gradient to this object's source image.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -177,18 +189,19 @@ class WhiteTextTitleOnly(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given font characteristics constitute a default
-        or custom font.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   True if a custom font is indicated, False otherwise.
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != WhiteTextTitleOnly.TITLE_FONT)
             or (font.size != 1.0)
             or (font.color != WhiteTextTitleOnly.TITLE_COLOR)
-            or (font.replacements != WhiteTextTitleOnly.FONT_REPLACEMENTS)
             or (font.vertical_shift != 0)
             or (font.interline_spacing != 0)
             or (font.kerning != 1.0)
@@ -196,17 +209,18 @@ class WhiteTextTitleOnly(BaseCardType):
 
 
     @staticmethod
-    def is_custom_season_titles(custom_episode_map: bool, 
-                                episode_text_format: str) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      custom_episode_map:     Whether the EpisodeMap was
-                                            customized.
-        :param      episode_text_format:    The episode text format in use.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   False, as season titles are not used by this card.
+        Returns:
+            False, as custom season titles are not used.
         """
 
         return False

--- a/Wdvh/WhiteTextTitleOnlyLogo.py
+++ b/Wdvh/WhiteTextTitleOnlyLogo.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 from modules.BaseCardType import BaseCardType
 from modules.Debug import log
@@ -51,12 +52,21 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
     )
 
 
-    def __init__(self, output_file: Path, title: str, font: str,
-                 font_size: float, title_color: str, blur: bool=False,
-                 grayscale: bool=False, vertical_shift: int=0,
-                 kerning: float=1.0, interline_spacing: int=0,
-                 stroke_width: float=1.0, logo: str=None, 
-                 background: str='#000000', **kwargs) -> None:
+    def __init__(self, *,
+            output_file: Path,
+            title: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            kerning: float = 1.0,
+            interline_spacing: int = 0,
+            stroke_width: float = 1.0,
+            logo: Optional[str] = None, 
+            background: str = '#000000',
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -72,7 +82,7 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
             interline_spacing: Pixel count to adjust title interline spacing by.
             kerning: Scalar to apply to kerning of the title text.
             stroke_width: Scalar to apply to black stroke of the title text.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -100,12 +110,13 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
         self.background = background
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 180 * self.font_size
@@ -122,11 +133,12 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self) -> list:
+    def __title_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 4.0 * self.stroke_width
@@ -142,7 +154,8 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
         """
         Resize the logo into at most a 1875x1030 bounding box.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -162,7 +175,8 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
         """
         Add the resized logo to a fixed color backdrop.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         # Get height of the resized logo to determine offset
@@ -223,12 +237,14 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given font characteristics constitute a default
-        or custom font.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   True if a custom font is indicated, False otherwise.
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != WhiteTextTitleOnlyLogo.TITLE_FONT)
@@ -242,17 +258,18 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
 
 
     @staticmethod
-    def is_custom_season_titles(custom_episode_map: bool, 
-                                episode_text_format: str) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      custom_episode_map:     Whether the EpisodeMap was
-                                            customized.
-        :param      episode_text_format:    The episode text format in use.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   False, as season titles are not used by this card.
+        Returns:
+            False, as custom season titles are not used.
         """
 
         return False
@@ -260,8 +277,8 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Skip card if logo doesn't exist

--- a/Wdvh/WhiteTextTitleOnlyLogo.py
+++ b/Wdvh/WhiteTextTitleOnlyLogo.py
@@ -212,6 +212,7 @@ class WhiteTextTitleOnlyLogo(BaseCardType):
             f'-annotate +0+{vertical_shift} "{self.title}"',
             f'-fill "{self.title_color}"',
             f'-annotate +0+{vertical_shift} "{self.title}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Yozora/BarebonesTitleCard.py
+++ b/Yozora/BarebonesTitleCard.py
@@ -180,6 +180,7 @@ class BarebonesTitleCard(BaseCardType):
         command = ' '.join([
             f'convert "{resized_source.resolve()}"',
             *self.__add_title_text(),
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -201,6 +202,7 @@ class BarebonesTitleCard(BaseCardType):
             f'convert "{resized_source.resolve()}"',
             *self.__add_title_text(),
             *self.__add_episode_text(),
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Yozora/BarebonesTitleCard.py
+++ b/Yozora/BarebonesTitleCard.py
@@ -9,8 +9,8 @@ from modules.RemoteFile import RemoteFile
 
 class BarebonesTitleCard(BaseCardType):
     """
-    This class describes a type of ImageMaker that produces title cards in the
-    theme of Star Wars cards as designed by reddit user /u/Olivier_286.
+    Yozora's barebones card type that is inspired by the Olivier and
+    StarWars card types.
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -49,11 +49,19 @@ class BarebonesTitleCard(BaseCardType):
     )
 
     
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 episode_text: str, font: str, font_size: float,
-                 title_color: str, episode_text_color: str=EPISODE_TEXT_COLOR,
-                 blur: bool=False, grayscale: bool=False,
-                 stroke_width: float=1.0, **kwargs) -> None:
+    def __init__(self, *,
+            source: Path,
+            output_file: Path,
+            title: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            episode_text_color: str = EPISODE_TEXT_COLOR,
+            blur: bool = False,
+            grayscale: bool = False,
+            stroke_width: float = 1.0,
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -69,7 +77,7 @@ class BarebonesTitleCard(BaseCardType):
             blur: Whether to blur the source image.
             grayscale: Whether to make the source image grayscale.
             stroke_width: Scalar to apply to black stroke of the title text.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -119,7 +127,7 @@ class BarebonesTitleCard(BaseCardType):
 
         return self.__RESIZED_SOURCE
 
-    def __add_title_text(self) -> list:
+    def __add_title_text(self) -> list[str]:
         """
         ImageMagick commands to add the episode title text to an image.
         
@@ -146,7 +154,7 @@ class BarebonesTitleCard(BaseCardType):
         ]
 
 
-    def __add_episode_text(self) -> list:
+    def __add_episode_text(self) -> list[str]:
         """
         ImageMagick commands to add the episode text to an image.
         
@@ -216,12 +224,14 @@ class BarebonesTitleCard(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given arguments represent a custom font for this
-        card. This CardType does not use custom fonts, so this is always False.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   False, as fonts are not customizable with this card.
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != BarebonesTitleCard.TITLE_FONT)
@@ -231,18 +241,18 @@ class BarebonesTitleCard(BaseCardType):
 
 
     @staticmethod
-    def is_custom_season_titles(custom_episode_map: bool, 
-                                episode_text_format: str) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      episode_text_format:    The episode text format in use.
-        :param      args and kwargs:        Generic arguments to permit 
-                                            generalized function calls for any
-                                            CardType.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   True if custom season titles are indicated, False otherwise.
+        Returns:
+            True if custom season titles are indicated, False otherwise.
         """
 
         standard_etf = BarebonesTitleCard.EPISODE_TEXT_FORMAT.upper()

--- a/Yozora/BarebonesTitleCard.py
+++ b/Yozora/BarebonesTitleCard.py
@@ -112,9 +112,11 @@ class BarebonesTitleCard(BaseCardType):
         """
         Resize the source image.
         
-        :param      source: The source image to modify.
+        Args:
+            source: The source image to modify.
         
-        :returns:   Path to the resized image.
+        Returns:
+            Path to the resized image.
         """
 
         command = ' '.join([
@@ -182,9 +184,11 @@ class BarebonesTitleCard(BaseCardType):
         """
         Add the title to the given image.
         
-        :param      resized_source: Resized source image.
+        Args:
+            resized_source: Resized source image.
         
-        :returns:   Path to the created image (the output file).
+        Returns:
+            Path to the created image (the output file).
         """
 
         command = ' '.join([
@@ -203,9 +207,11 @@ class BarebonesTitleCard(BaseCardType):
         """
         Add the title and episode text to the given image.
         
-        :param      resized_source: Resized source image.
+        Args:
+            resized_source: Resized source image.
         
-        :returns:   Path to the created image (the output file).
+        Returns:
+            Path to the created image (the output file).
         """
 
         command = ' '.join([

--- a/Yozora/BarebonesTitleCard.py
+++ b/Yozora/BarebonesTitleCard.py
@@ -123,7 +123,8 @@ class BarebonesTitleCard(BaseCardType):
         """
         ImageMagick commands to add the episode title text to an image.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 6.0 * self.stroke_width
@@ -149,7 +150,8 @@ class BarebonesTitleCard(BaseCardType):
         """
         ImageMagick commands to add the episode text to an image.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [

--- a/Yozora/RetroTitleCard.py
+++ b/Yozora/RetroTitleCard.py
@@ -6,8 +6,8 @@ from modules.RemoteFile import RemoteFile
 
 class RetroTitleCard(BaseCardType):
     """
-    This class describes a CardType designed by Yozora. This card type is retro-
-    themed, and features either a Rewind/Play overlay.
+    This class describes a CardType designed by Yozora. This card type
+    is retro-themed, and features either a Rewind/Play overlay.
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -23,8 +23,9 @@ class RetroTitleCard(BaseCardType):
     """Default font characteristics for the title text"""
     TITLE_FONT = str(RemoteFile('Yozora', 'ref/retro/retro.ttf'))
     TITLE_COLOR = '#FFFFFF'
-    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']', '―': '-',
-                         '…': '...'}
+    FONT_REPLACEMENTS = {
+        '[': '(', ']': ')', '(': '[', ')': ']', '―': '-', '…': '...'
+    }
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = True
@@ -55,13 +56,24 @@ class RetroTitleCard(BaseCardType):
     )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 episode_text: str, font: str, font_size: float,
-                 title_color: str, watched: bool=True, blur: bool=False,
-                 grayscale: bool=False, vertical_shift: int=0,
-                 interline_spacing: int=0, kerning: float=1.0,
-                 stroke_width: float=1.0, override_bw: str='',
-                 override_style: str='', **kwargs) -> None:
+    def __init__(self, *,
+            source: Path,
+            output_file: Path,
+            title: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            watched: bool = True,
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            override_bw: str = '',
+            override_style: str = '',
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -86,7 +98,7 @@ class RetroTitleCard(BaseCardType):
             override_bw: Override B/W modification based on watch status.
             override_style: Override the play/rewind style basd on watch status.
                 Should be 'rewind' or 'play'.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -113,12 +125,13 @@ class RetroTitleCard(BaseCardType):
         self.override_style = override_style.lower()
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 150 * self.font_size
@@ -135,11 +148,12 @@ class RetroTitleCard(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self) -> list:
+    def __title_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 3.0 * self.stroke_width
@@ -151,12 +165,13 @@ class RetroTitleCard(BaseCardType):
         ]
 
 
-    def __series_count_text_global_effects(self) -> list:
+    def __series_count_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -165,12 +180,13 @@ class RetroTitleCard(BaseCardType):
         ]
 
 
-    def __series_count_text_black_stroke(self) -> list:
+    def __series_count_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -180,12 +196,13 @@ class RetroTitleCard(BaseCardType):
         ]
 
 
-    def __series_count_text_effects(self) -> list:
+    def __series_count_text_effects(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -199,7 +216,8 @@ class RetroTitleCard(BaseCardType):
         """
         Add the static gradient to this object's source image.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
         
         # Select gradient overlay based on override/watch status
@@ -294,18 +312,19 @@ class RetroTitleCard(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given font characteristics constitute a default
-        or custom font.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   True if a custom font is indicated, False otherwise.
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != RetroTitleCard.TITLE_FONT)
             or (font.size != 1.0)
             or (font.color != RetroTitleCard.TITLE_COLOR)
-            or (font.replacements != RetroTitleCard.FONT_REPLACEMENTS)
             or (font.vertical_shift != 0)
             or (font.interline_spacing != 0)
             or (font.kerning != 1.0)
@@ -313,17 +332,18 @@ class RetroTitleCard(BaseCardType):
 
 
     @staticmethod
-    def is_custom_season_titles(custom_episode_map: bool, 
-                                episode_text_format: str) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      custom_episode_map:     Whether the EpisodeMap was
-                                            customized.
-        :param      episode_text_format:    The episode text format in use.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   True if custom season titles are indicated, False otherwise.
+        Returns:
+            False, as custom season titles are not used.
         """
 
         return False
@@ -331,8 +351,8 @@ class RetroTitleCard(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Add the gradient to the source image (always)

--- a/Yozora/RetroTitleCard.py
+++ b/Yozora/RetroTitleCard.py
@@ -282,6 +282,7 @@ class RetroTitleCard(BaseCardType):
             f'-annotate +200+229 "{self.episode_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +200+229 "{self.episode_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -339,9 +340,6 @@ class RetroTitleCard(BaseCardType):
 
         # Add either one or two lines of episode text 
         titled_image = self._add_title_text(gradient_image)
-
-        # Create the output directory and any necessary parents 
-        self.output_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Add episode text 
         self._add_series_count_text(titled_image)

--- a/Yozora/SlimTitleCard.py
+++ b/Yozora/SlimTitleCard.py
@@ -254,6 +254,7 @@ class SlimTitleCard(BaseCardType):
             f'-annotate +0+697.2 "{self.episode_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +0+697.2 "{self.episode_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -363,6 +364,7 @@ class SlimTitleCard(BaseCardType):
             f'-geometry +0+830',
             f'"{series_count_image.resolve()}"',
             f'"{titled_image.resolve()}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Yozora/SlimTitleCard.py
+++ b/Yozora/SlimTitleCard.py
@@ -377,13 +377,11 @@ class SlimTitleCard(BaseCardType):
         """
 
         command = ' '.join([
-            f'convert',
+            f'composite',
             f'-gravity center',
             f'-geometry +0+830',
             f'"{series_count_image.resolve()}"',
             f'"{titled_image.resolve()}"',
-            f'-composite',
-            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/Yozora/SlimTitleCard.py
+++ b/Yozora/SlimTitleCard.py
@@ -28,8 +28,9 @@ class SlimTitleCard(BaseCardType):
     TITLE_COLOR = '#FFFFFF'
 
     """Default characters to replace in the generic font"""
-    FONT_REPLACEMENTS = {'…': '...', '[': '(', ']': ')', '(': '[', ')': ']', 
-                         '―': '-'}
+    FONT_REPLACEMENTS = {
+        '…': '...', '[': '(', ']': ')', '(': '[', ')': ']', '―': '-'
+    }
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = True
@@ -57,12 +58,23 @@ class SlimTitleCard(BaseCardType):
     )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 season_text: str, episode_text: str, font: str,
-                 font_size: float, title_color: str, hide_season: bool,
-                 blur: bool=False, grayscale: bool=False, vertical_shift: int=0,
-                 interline_spacing: int=0, kerning: float=1.0,
-                 stroke_width: float=1.0, **kwargs) -> None:
+    def __init__(self,
+            source: Path,
+            output_file: Path,
+            title: str,
+            season_text: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            hide_season: bool = False,
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -82,7 +94,7 @@ class SlimTitleCard(BaseCardType):
             interline_spacing: Pixel count to adjust title interline spacing by.
             kerning: Scalar to apply to kerning of the title text.
             stroke_width: Scalar to apply to black stroke of the title text.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -106,12 +118,13 @@ class SlimTitleCard(BaseCardType):
         self.stroke_width = stroke_width
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 157.41 * self.font_size
@@ -128,11 +141,12 @@ class SlimTitleCard(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self) -> list:
+    def __title_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 1.0 * self.stroke_width
@@ -144,12 +158,13 @@ class SlimTitleCard(BaseCardType):
         ]
 
 
-    def __series_count_text_global_effects(self) -> list:
+    def __series_count_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -158,12 +173,13 @@ class SlimTitleCard(BaseCardType):
         ]
 
 
-    def __series_count_text_black_stroke(self) -> list:
+    def __series_count_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -173,12 +189,13 @@ class SlimTitleCard(BaseCardType):
         ]
 
 
-    def __series_count_text_effects(self) -> list:
+    def __series_count_text_effects(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -192,7 +209,8 @@ class SlimTitleCard(BaseCardType):
         """
         Add the static gradient to this object's source image.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -376,12 +394,14 @@ class SlimTitleCard(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given font characteristics constitute a default
-        or custom font.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   True if a custom font is indicated, False otherwise.
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != SlimTitleCard.TITLE_FONT)
@@ -394,11 +414,11 @@ class SlimTitleCard(BaseCardType):
 
 
     @staticmethod
-    def is_custom_season_titles(custom_episode_map: bool, 
-                                episode_text_format: str) -> bool:
+    def is_custom_season_titles(
+            custom_episode_map: bool, episode_text_format: str) -> bool:
         """
-        Determine whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
         Args:
             custom_episode_map: Whether the EpisodeMap was customized.
@@ -417,8 +437,8 @@ class SlimTitleCard(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Add the gradient to the source image (always)

--- a/Yozora/SlimTitleCard.py
+++ b/Yozora/SlimTitleCard.py
@@ -377,11 +377,12 @@ class SlimTitleCard(BaseCardType):
         """
 
         command = ' '.join([
-            f'composite',
+            f'convert',
             f'-gravity center',
             f'-geometry +0+830',
             f'"{series_count_image.resolve()}"',
             f'"{titled_image.resolve()}"',
+            f'-composite',
             *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])

--- a/azuravian/TitleColorMatch.py
+++ b/azuravian/TitleColorMatch.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from re import findall, compile as re_compile
+from typing import Optional
 
 from modules.BaseCardType import BaseCardType
 from modules.CleanPath import CleanPath
@@ -9,10 +10,10 @@ from modules.RemoteFile import RemoteFile
 class TitleColorMatch(BaseCardType):
     """
     This class describes a type of CardType created by azuravian, and is 
-    a modification of Beedman's GradientLogoTitleCard class with a few changes, 
-    specifically the ability to autoselect a font color that matches the logo, 
-    as well as trimming the logo of any extra transparent space that makes its 
-    location incorrect.
+    a modification of Beedman's GradientLogoTitleCard class with a few
+    changes,  specifically the ability to autoselect a font color that
+    matches the logo, as well as trimming the logo of any extra
+    transparent space that makes its  location incorrect.
     """
     
     """Directory where all reference files used by this card are stored"""
@@ -30,8 +31,9 @@ class TitleColorMatch(BaseCardType):
     TITLE_COLOR = '#EBEBEB'
 
     """Default characters to replace in the generic font"""
-    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']', '―': '-',
-                         '…': '...'}
+    FONT_REPLACEMENTS = {
+        '[': '(', ']': ')', '(': '[', ')': ']', '―': '-', '…': '...'
+    }
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = True
@@ -63,23 +65,28 @@ class TitleColorMatch(BaseCardType):
     )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 season_text: str, episode_text: str, font: str,
-                 font_size: float, title_color: str, hide_season: bool,
-                 vertical_shift: int=0,
-                 interline_spacing: int=0,
-                 kerning: float=1.0,
-                 stroke_width: float=1.0,
-                 season_number: int=1,
-                 episode_number: int=1,
-                 blur: bool=False,
-                 grayscale: bool=False,
-                 logo: str=None,
-                 **unused) -> None:
+    def __init__(self,
+            source: Path,
+            output_file: Path,
+            title: str,
+            season_text: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            hide_season: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            season_number: int = 1,
+            episode_number: int = 1,
+            blur: bool = False,
+            grayscale: bool = False,
+            logo: Optional[str] = None,
+            **unused) -> None:
         """
-        Initialize the TitleCardMaker object. This primarily just stores
-        instance variables for later use in `create()`. If the provided font
-        does not have a character in the title text, a space is used instead.
+        Construct a new instance of this card.
 
         Args:
             source: Source image.
@@ -90,14 +97,15 @@ class TitleColorMatch(BaseCardType):
             font: Font to use for the episode title.
             font_size: Scalar to apply to the title font size.
             title_color: Color to use for the episode title.
-            hide_season: Whether to omit the season text (and joining character)
-                from the title card completely.
+            hide_season: Whether to omit the season text (and joining
+                character) from the title card completely.
             blur: Whether to blur the source image.
             grayscale: Whether to make the source image grayscale.
             vertical_shift: Pixels to adjust title vertical shift by.
-            interline_spacing: Pixels to adjust title interline spacing by.
+            interline_spacing: Pixels to adjust title interline spacing.
             kerning: Scalar to apply to kerning of the title text.
-            stroke_width: Scalar to apply to black stroke of the title text.
+            stroke_width: Scalar to apply to black stroke of the title
+                text.
             logo: Filepath to the logo file.
             kwargs: Unused arguments.
         """
@@ -134,12 +142,14 @@ class TitleColorMatch(BaseCardType):
         self.stroke_width = stroke_width
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
-        ImageMagick commands to implement the title text's global effects.
-        Specifically the the font, kerning, fontsize, and center gravity.
+        ImageMagick commands to implement the title text's global
+        effects. Specifically the the font, kerning, fontsize, and
+        center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 157.41 * self.font_size
@@ -156,11 +166,12 @@ class TitleColorMatch(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self, stroke) -> list:
+    def __title_text_black_stroke(self, stroke) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 3.0 * self.stroke_width
@@ -177,7 +188,8 @@ class TitleColorMatch(BaseCardType):
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -191,7 +203,8 @@ class TitleColorMatch(BaseCardType):
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -206,7 +219,8 @@ class TitleColorMatch(BaseCardType):
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -219,7 +233,8 @@ class TitleColorMatch(BaseCardType):
         """
         Resize the logo into at most a 1155x650 bounding box.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
         
         command = ' '.join([
@@ -239,7 +254,8 @@ class TitleColorMatch(BaseCardType):
         """
         Add the static gradient to this object's source image.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -259,7 +275,8 @@ class TitleColorMatch(BaseCardType):
         """
         Add the resized logo to the same intermediate image as above because that's what worked.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([

--- a/azuravian/TitleColorMatch.py
+++ b/azuravian/TitleColorMatch.py
@@ -407,6 +407,7 @@ class TitleColorMatch(BaseCardType):
             f'-annotate +50+50 "{self.episode_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +50+50 "{self.episode_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -516,6 +517,7 @@ class TitleColorMatch(BaseCardType):
             f'-geometry +50+50',
             f'"{series_count_image.resolve()}"',
             f'"{titled_image.resolve()}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/azuravian/TitleColorMatch.py
+++ b/azuravian/TitleColorMatch.py
@@ -49,12 +49,6 @@ class TitleColorMatch(BaseCardType):
     EPISODE_COUNT_FONT = REF_DIRECTORY / 'Proxima Nova Regular.otf'
     SERIES_COUNT_TEXT_COLOR = '#CFCFCF'
 
-    """Paths to intermediate files that are deleted after the card is created"""
-    __RESIZED_LOGO = BaseCardType.TEMP_DIR / 'resized_logo.png'
-    __SOURCE_WITH_GRADIENT = BaseCardType.TEMP_DIR / 'source_gradient.png'
-    __GRADIENT_WITH_TITLE = BaseCardType.TEMP_DIR / 'gradient_title.png'
-    __SERIES_COUNT_TEXT = BaseCardType.TEMP_DIR / 'series_count_text.png'
-
     """Regex to match colors/counts in ImageMagick histograms"""
     __COLORDATA_REGEX = re_compile(r'[\s]*(\d*)?:\s.*\s(#\w{8}).*\n?')
 
@@ -142,19 +136,51 @@ class TitleColorMatch(BaseCardType):
         self.stroke_width = stroke_width
 
 
-    def __title_text_global_effects(self) -> list[str]:
+    @property
+    def logo_command(self) -> list[str]:
         """
-        ImageMagick commands to implement the title text's global
-        effects. Specifically the the font, kerning, fontsize, and
-        center gravity.
-        
+        Get the ImageMagick commands to add the resized logo to the
+        source image.
+
         Returns:
             List of ImageMagick commands.
         """
 
+        return [
+            # Resize logo
+            f'\( "{self.logo.resolve()}"',
+            f'-trim',
+            f'+repage',
+            f'-resize x650',
+            f'-resize 1155x650\> \)',
+            # Overlay resized logo
+            f'-gravity northwest',
+            f'-define colorspace:auto-grayscale=false',
+            f'-type TrueColorAlpha',  
+            f'-geometry "+50+50"',
+            f'-composite',
+        ]
+
+
+    @property
+    def title_text(self) -> list[str]:
+        """
+        ImageMagick commands to implement the title text's global
+        effects. Specifically the the font, kerning, fontsize, and
+        center gravity.
+
+        Returns:
+            List of ImageMagick commands.
+        """
+
+        # Get the title color and stroke for this logo
+        title_color, stroke_color = self._get_logo_color()
+
         font_size = 157.41 * self.font_size
         interline_spacing = -22 + self.interline_spacing
         kerning = -1.25 * self.kerning
+        stroke_width = 3.0 * self.stroke_width
+        vertical_shift = 125 + self.vertical_shift
 
         return [
             f'-font "{self.font}"',
@@ -163,167 +189,27 @@ class TitleColorMatch(BaseCardType):
             f'-interline-spacing {interline_spacing}',
             f'-pointsize {font_size}',
             f'-gravity southwest',
+            f'-fill {stroke_color}',
+            f'-stroke {stroke_color}',
+            f'-strokewidth {stroke_width}',
+            f'-annotate +50+{vertical_shift} "{self.title}"',
+            f'-fill "{title_color}"',
+            f'-annotate +50+{vertical_shift} "{self.title}"',
         ]   
 
 
-    def __title_text_black_stroke(self, stroke) -> list[str]:
-        """
-        ImageMagick commands to implement the title text's black stroke.
-        
-        Returns:
-            List of ImageMagick commands.
-        """
-
-        stroke_width = 3.0 * self.stroke_width
-
-        return [
-            f'-fill {stroke}',
-            f'-stroke {stroke}',
-            f'-strokewidth {stroke_width}',
-        ]
-
-
-    def __series_count_text_global_effects(self) -> list:
-        """
-        ImageMagick commands for global text effects applied to all series count
-        text (season/episode count and dot).
-        
-        Returns:
-            List of ImageMagick commands.
-        """
-
-        return [
-            f'-kerning 5.42',
-            f'-pointsize 67.75',
-        ]
-
-
-    def __series_count_text_black_stroke(self) -> list:
-        """
-        ImageMagick commands for adding the necessary black stroke effects to
-        series count text.
-        
-        Returns:
-            List of ImageMagick commands.
-        """
-
-        return [
-            f'-fill black',
-            f'-stroke black',
-            f'-strokewidth 6',
-        ]
-
-
-    def __series_count_text_effects(self) -> list:
-        """
-        ImageMagick commands for adding the necessary text effects to the series
-        count text.
-        
-        Returns:
-            List of ImageMagick commands.
-        """
-
-        return [
-            f'-fill "{self.SERIES_COUNT_TEXT_COLOR}"',
-            f'-stroke "{self.SERIES_COUNT_TEXT_COLOR}"',
-            f'-strokewidth 0.75',
-        ]
-
-    def _resize_logo(self) -> Path:
-        """
-        Resize the logo into at most a 1155x650 bounding box.
-        
-        Returns:
-            Path to the created image.
-        """
-        
-        command = ' '.join([
-            f'convert',
-            f'"{self.logo.resolve()}"',
-            f'-trim +repage',
-            f'-resize x650',
-            f'-resize 1155x650\>',
-            f'"{self.__RESIZED_LOGO.resolve()}"',
-        ])
-
-        self.image_magick.run(command)
-
-        return self.__RESIZED_LOGO
-        
-    def _add_gradient(self) -> Path:
-        """
-        Add the static gradient to this object's source image.
-        
-        Returns:
-            Path to the created image.
-        """
-
-        command = ' '.join([
-            f'convert "{self.source_file.resolve()}"',
-            *self.resize_and_style,
-            f'"{self.__GRADIENT_IMAGE}"',
-            f'-background None',
-            f'-layers Flatten',
-            f'"{self.__SOURCE_WITH_GRADIENT.resolve()}"',
-        ])
-
-        self.image_magick.run(command)
-
-        return self.__SOURCE_WITH_GRADIENT
-
-    def _add_logo_to_backdrop(self, resized_logo: Path, gradient_image: Path) -> Path:
-        """
-        Add the resized logo to the same intermediate image as above because that's what worked.
-        
-        Returns:
-            Path to the created image.
-        """
-
-        command = ' '.join([
-            f'convert "{gradient_image.resolve()}"',
-            f'"{resized_logo.resolve()}"',
-            f'-gravity northwest',
-            # Keep color logo on a black and white image
-            f'-define colorspace:auto-grayscale=false',
-            f'-type TrueColorAlpha',  
-            f'-geometry "+50+50"',
-            f'-composite "{self.__SOURCE_WITH_GRADIENT.resolve()}"',
-        ])
-
-        self.image_magick.run(command)
-
-        return self.__SOURCE_WITH_GRADIENT
-
-
-    def _hex_to_rgb(self, value: str) -> tuple[int, int, int]:
-        """
-        Convert the given hex color to an RGB tuple.
-
-        Args:
-            value: Hex value to convert
-
-        Returns:
-            Tuple of integers that are RGB.
-        """
-
-        value = value.lstrip('#')
-        lv = len(value)
-
-        return tuple(int(value[i:i + lv // 3], 16) for i in range(0, lv, lv//3))
-
-
-    def _get_logo_color(self) -> tuple[str, tuple[int, int, int]]:
+    def _get_logo_color(self) -> tuple[str, str]:
         """
         Get the logo color for this card's logo.
 
         Returns:
-            Tuple whose values are the title color text and the RGB color
-            values.
+            Tuple whose values are the title color text and the stroke
+            width color.
         """
 
-        # If auto color wasn't indicated
+        # If auto color wasn't indicated use indicated color and black stroke
         if self.title_color.lower() != 'auto':
-            return self.title_color, None
+            return self.title_color, 'black'
 
         # Command to get histogram of the colors in logo image
         command = ' '.join([
@@ -336,8 +222,10 @@ class TitleColorMatch(BaseCardType):
 
         # Get color data
         colordata = self.image_magick.run_get_output(command)
-        cdata = {k: [num, hex] for k, (num, hex)
-                 in enumerate(findall(self.__COLORDATA_REGEX,colordata),start=1)}
+        cdata = {
+            k: [num, hex_] for k, (num, hex_)
+            in enumerate(findall(self.__COLORDATA_REGEX, colordata), start=1)
+        }
 
         translist = []
         pixcount = []
@@ -355,192 +243,82 @@ class TitleColorMatch(BaseCardType):
         pixcount.sort(reverse=True)
         pairs = list(cdata.values())
         for num in pixcount:
-            hexcolor = next(x[1][:7] for x in pairs if int(x[0])==num)
-            rgb = self._hex_to_rgb(hexcolor)
+            # Get the RGB value from the hexcolor
+            hexcolor = next(x[1][:7] for x in pairs if int(x[0]) == num)
+
+            color_ = hexcolor.lstrip('#')
+            lv = len(color_)
+            r, g, b = (int(color_[i:i+lv//3], 16) for i in range(0, lv, lv//3))
+            
             # Skip values that are too dark/light
-            if min(rgb) > 240 or max(rgb) < 15:
+            if min(r, g, b) > 240 or max(r, g, b) < 15:
                 continue
-            else:
-                return hexcolor, rgb
+
+            # First valid color, return color and stroke based on luminance
+            luminance = (r * 0.299) + (g * 0.587) + (b * 0.114)
+            return hexcolor, 'black' if luminance > 50 else 'white'
 
         # No valid colors identified, return defaults
-        return self.TITLE_COLOR, (235, 235, 235)
+        return self.TITLE_COLOR, 'black'
 
     
-    def _add_title_text(self, gradient_image: Path) -> Path:
+    @property
+    def index_text_command(self) -> list[str]:
         """
-        Adds episode title text to the provided image.
+        Get the ImageMagick commands required to add the index (season
+        and episode) text to the image.
 
-        :param      gradient_image: The image with gradient added.
-        
-        :returns:   Path to the created image that has a gradient and the title
-                    text added.
-        """
-        
-        # Get the title color for this logo (if indicated)
-        t_color, rgb = self._get_logo_color()
-
-        # If a valid color was found, get apparant luminance
-        if rgb is not None:
-            r, g, b = rgb
-            lum = (r*0.299 + g*0.587 + b*0.114)
-        else:
-            lum = 255
-
-        # Use white stroke only if luminance is very low
-        stroke = 'black' if lum > 50 else 'white'
-        vertical_shift = 125 + self.vertical_shift
-
-        command = ' '.join([
-            f'convert "{gradient_image.resolve()}"',
-            *self.__title_text_global_effects(),
-            *self.__title_text_black_stroke(stroke),
-            f'-annotate +50+{vertical_shift} "{self.title}"',
-            f'-fill "{t_color}"',
-            f'-annotate +50+{vertical_shift} "{self.title}"',
-            f'"{self.__GRADIENT_WITH_TITLE.resolve()}"',
-        ])
-
-        self.image_magick.run(command)
-
-        return self.__GRADIENT_WITH_TITLE
-
-
-    def _add_series_count_text_no_season(self, titled_image: Path) -> Path:
-        """
-        Adds the series count text without season title/number.
-        
-        :param      titled_image:  The titled image to add text to.
-
-        :returns:   Path to the created image (the output file).
+        Returns:
+            List of ImageMagick commands.
         """
 
-        command = ' '.join([
-            f'convert "{titled_image.resolve()}"',
-            *self.__series_count_text_global_effects(),
-            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
-            f'-gravity southwest',
-            *self.__series_count_text_black_stroke(),
-            f'-annotate +50+50 "{self.episode_text}"',
-            *self.__series_count_text_effects(),
-            f'-annotate +50+50 "{self.episode_text}"',
-            *self.resize_output,
-            f'"{self.output_file.resolve()}"',
-        ])
+        # Season hiding, just add episode text
+        if self.hide_season:
+            return [
+                f'-kerning 5.42',
+                f'-pointsize 67.75',
+                f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
+                f'-gravity southwest',
+                f'-fill black',
+                f'-stroke black',
+                f'-strokewidth 6',
+                f'-annotate +50+50 "{self.episode_text}"',
+                f'-fill "{self.SERIES_COUNT_TEXT_COLOR}"',
+                f'-stroke "{self.SERIES_COUNT_TEXT_COLOR}"',
+                f'-strokewidth 0.75',
+                f'-annotate +50+50 "{self.episode_text}"',
+            ]
 
-        self.image_magick.run(command)
-
-        return self.output_file
-
-
-    def _get_series_count_text_dimensions(self) -> dict:
-        """
-        Gets the series count text dimensions.
-        
-        :returns:   The series count text dimensions.
-        """
-
-        command = ' '.join([
-            f'convert -debug annotate xc: ',
-            *self.__series_count_text_global_effects(),
-            f'-font "{self.SEASON_COUNT_FONT.resolve()}"',
-            f'-gravity east',
-            *self.__series_count_text_effects(),
-            f'-annotate +1600+697.2 "{self.season_text} "',
-            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
-            f'-gravity center',
-            *self.__series_count_text_effects(),
-            f'-annotate +0+689.5 "• "',
-            f'-gravity west',
-            *self.__series_count_text_effects(),
-            f'-annotate +1640+697.2 "{self.episode_text}"',
-            f'null: 2>&1'
-        ])
-
-        # Get text dimensions from the output
-        metrics = self.image_magick.run_get_output(command)
-        widths = list(map(int, findall(r'Metrics:.*width:\s+(\d+)', metrics)))
-        heights = list(map(int, findall(r'Metrics:.*height:\s+(\d+)', metrics)))
-
-        # Don't raise IndexError if no dimensions were found
-        if len(widths) < 2 or len(heights) < 2:
-            log.warning(f'Unable to identify font dimensions, file bug report')
-            widths = [370, 47, 357]
-            heights = [68, 83, 83]
-
-        return {
-            'width':    sum(widths),
-            'width1':   widths[0],
-            'width2':   widths[1],
-            'height':   max(heights)+25,
-        }
-
-
-    def _create_series_count_text_image(self, width: float, width1: float,
-                                        width2: float, height: float) -> Path:
-        """
-        Creates an image with only series count text. This image is transparent,
-        and not any wider than is necessary (as indicated by `dimensions`).
-        
-        :returns:   Path to the created image containing only series count text.
-        """
-
-        # Create text only transparent image of season count text
-        command = ' '.join([
-            f'convert -size "{width}x{height}"',
-            f'-alpha on',
+        return [
             f'-background transparent',
-            f'xc:transparent',
-            *self.__series_count_text_global_effects(),
+            f'+interword-spacing',
+            f'-kerning 5.42',
+            f'-pointsize 67.75',
+            f'-fill black',
+            f'-stroke black',
+            f'-strokewidth 6',
+            f'\( -gravity center',
             f'-font "{self.SEASON_COUNT_FONT.resolve()}"',
-            *self.__series_count_text_black_stroke(),
-            f'-annotate +0+{height-25} "{self.season_text} "',
-            *self.__series_count_text_effects(),
-            f'-annotate +0+{height-25} "{self.season_text} "',
+            f'label:"{self.season_text} •"',
             f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
-            *self.__series_count_text_black_stroke(),
-            f'-annotate +{width1}+{height-25-6.5} "•"',
-            *self.__series_count_text_effects(),
-            f'-annotate +{width1}+{height-25-6.5} "•"',
-            *self.__series_count_text_black_stroke(),
-            f'-annotate +{width1+width2}+{height-25} "{self.episode_text}"',
-            *self.__series_count_text_effects(),
-            f'-annotate +{width1+width2}+{height-25} "{self.episode_text}"',
-            f'"PNG32:{self.__SERIES_COUNT_TEXT.resolve()}"',
-        ])
-
-        self.image_magick.run(command)
-
-        return self.__SERIES_COUNT_TEXT
-
-
-    def _combine_titled_image_series_count_text(self, titled_image: Path,
-                                                series_count_image: Path)->Path:
-        """
-        Combine the titled image (image+gradient+episode title) and the series
-        count image (optional season number+optional dot+episode number) into a
-        single image. This is written into the output image for this object.
-
-        :param      titled_image:       Path to the titled image to add.
-        :param      series_count_image: Path to the series count transparent
-                                        image to add.
-
-        :returns:   Path to the created image (the output file).
-        """
-
-        command = ' '.join([
-            f'composite',
+            f'label:"{self.episode_text}"',
+            f'+smush 30 \)',
             f'-gravity southwest',
             f'-geometry +50+50',
-            f'"{series_count_image.resolve()}"',
-            f'"{titled_image.resolve()}"',
-            *self.resize_output,
-            f'"{self.output_file.resolve()}"',
-        ])
-
-        self.image_magick.run(command)
-
-        return self.output_file
+            f'-composite',
+            f'-fill "{self.SERIES_COUNT_TEXT_COLOR}"',
+            f'-stroke "{self.SERIES_COUNT_TEXT_COLOR}"',
+            f'-strokewidth 0.75',
+            f'\( -gravity center',
+            f'-font "{self.SEASON_COUNT_FONT.resolve()}"',
+            f'label:"{self.season_text} •"',
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
+            f'label:"{self.episode_text}"',
+            f'+smush 30 \)',
+            f'-gravity southwest',
+            f'-geometry +50+50',
+            f'-composite',
+        ]
 
 
     @staticmethod
@@ -586,8 +364,8 @@ class TitleColorMatch(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Skip card if logo doesn't exist
@@ -597,35 +375,24 @@ class TitleColorMatch(BaseCardType):
         elif not self.logo.exists():
             log.error(f'Logo file "{self.logo.resolve()}" does not exist')
             return None
-            
-        # Resize logo
-        resized_logo = self._resize_logo()
-        
-        # Add the gradient to the source image (always)
-        gradient_image = self._add_gradient()
-        
-        # Create backdrop+logo image
-        backdrop_logo = self._add_logo_to_backdrop(resized_logo, gradient_image)
 
-        # Add either one or two lines of episode text 
-        titled_image = self._add_title_text(backdrop_logo)
+        command = ' '.join([
+            f'convert',
+            # Resize source image
+            f'"{self.source_file.resolve()}"',
+            *self.resize_and_style,
+            # Overlay gradient
+            f'"{self.__GRADIENT_IMAGE}"',
+            f'-composite',
+            # Overlay resized logo
+            *self.logo_command,
+            # Put title text
+            *self.title_text,
+            # Put season/episode text
+            *self.index_text_command,
+            # Create and resize output
+            *self.resize_output,
+            f'"{self.output_file.resolve()}"',
+        ])
 
-        # If season text is hidden, just add episode text 
-        if self.hide_season:
-            self._add_series_count_text_no_season(titled_image)
-        else:
-            # If adding season text, create intermediate images and combine them
-            series_count_image = self._create_series_count_text_image(
-                **self._get_series_count_text_dimensions()
-            )
-            self._combine_titled_image_series_count_text(
-                titled_image,
-                series_count_image
-            )
-
-        # Delete all intermediate images
-        images = [gradient_image, titled_image]
-        if not self.hide_season:
-            images.append(series_count_image)
-
-        self.image_magick.delete_intermediate_images(*images)
+        self.image_magick.run(command)

--- a/lyonza/WhiteTextBroadcast.py
+++ b/lyonza/WhiteTextBroadcast.py
@@ -7,7 +7,8 @@ from modules.RemoteFile import RemoteFile
 class WhiteTextBroadcast(BaseCardType):
     """
     This class describes lyonza's CardType based on Wvdh's
-    "WhiteTextBroadcast" card to show SxxExx format instead of absolute numbering
+    "WhiteTextBroadcast" card to show SxxExx format instead of absolute
+    numbering
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -25,8 +26,9 @@ class WhiteTextBroadcast(BaseCardType):
     TITLE_COLOR = '#FFFFFF'
 
     """Default characters to replace in the generic font"""
-    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']', '―': '-',
-                         '…': '...'}
+    FONT_REPLACEMENTS = {
+        '[': '(', ']': ')', '(': '[', ')': ']', '―': '-', '…': '...'
+    }
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = True
@@ -48,17 +50,28 @@ class WhiteTextBroadcast(BaseCardType):
     __SOURCE_WITH_GRADIENT = BaseCardType.TEMP_DIR / 'source_gradient.png'
     __GRADIENT_WITH_TITLE = BaseCardType.TEMP_DIR / 'gradient_title.png'
 
-    __slots__ = ('source_file', 'output_file', 'title',
-                 'episode_text', 'font', 'font_size', 'title_color',
-                 'hide_season', 'blur', 'vertical_shift', 'interline_spacing',
-                 'kerning', 'stroke_width')
+    __slots__ = (
+        'source_file', 'output_file', 'title', 'episode_text', 'font',
+        'font_size', 'title_color', 'hide_season', 'blur', 'vertical_shift',
+        'interline_spacing', 'kerning', 'stroke_width'
+    )
 
 
-    def __init__(self, source: Path, output_file: Path, title: str,
-                 episode_text: str, font: str, font_size: float,
-                 title_color: str, blur: bool=False, grayscale: bool=False,
-                 vertical_shift: int=0, interline_spacing: int=0,
-                 kerning: float=1.0, stroke_width: float=1.0, **kwargs) -> None:
+    def __init__(self, *,
+            source: Path,
+            output_file: Path,
+            title: str,
+            episode_text: str,
+            font: str,
+            font_size: float,
+            title_color: str,
+            blur: bool = False,
+            grayscale: bool = False,
+            vertical_shift: int = 0,
+            interline_spacing: int = 0,
+            kerning: float = 1.0,
+            stroke_width: float = 1.0,
+            **unused) -> None:
         """
         Initialize this CardType object.
 
@@ -76,7 +89,7 @@ class WhiteTextBroadcast(BaseCardType):
             interline_spacing: Pixel count to adjust title interline spacing by.
             kerning: Scalar to apply to kerning of the title text.
             stroke_width: Scalar to apply to black stroke of the title text.
-            kwargs: Unused arguments.
+            unused: Unused arguments.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -98,12 +111,13 @@ class WhiteTextBroadcast(BaseCardType):
         self.stroke_width = stroke_width
 
 
-    def __title_text_global_effects(self) -> list:
+    def __title_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's global effects.
         Specifically the the font, kerning, fontsize, and center gravity.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         font_size = 180 * self.font_size
@@ -120,11 +134,12 @@ class WhiteTextBroadcast(BaseCardType):
         ]   
 
 
-    def __title_text_black_stroke(self) -> list:
+    def __title_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands to implement the title text's black stroke.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         stroke_width = 3.0 * self.stroke_width
@@ -136,12 +151,13 @@ class WhiteTextBroadcast(BaseCardType):
         ]
 
 
-    def __series_count_text_global_effects(self) -> list:
+    def __series_count_text_global_effects(self) -> list[str]:
         """
         ImageMagick commands for global text effects applied to all series count
         text (season/episode count and dot).
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -150,12 +166,13 @@ class WhiteTextBroadcast(BaseCardType):
         ]
 
 
-    def __series_count_text_black_stroke(self) -> list:
+    def __series_count_text_black_stroke(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary black stroke effects to
         series count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -165,12 +182,13 @@ class WhiteTextBroadcast(BaseCardType):
         ]
 
 
-    def __series_count_text_effects(self) -> list:
+    def __series_count_text_effects(self) -> list[str]:
         """
         ImageMagick commands for adding the necessary text effects to the series
         count text.
         
-        :returns:   List of ImageMagick commands.
+        Returns:
+            List of ImageMagick commands.
         """
 
         return [
@@ -184,7 +202,8 @@ class WhiteTextBroadcast(BaseCardType):
         """
         Add the static gradient to this object's source image.
         
-        :returns:   Path to the created image.
+        Returns:
+            Path to the created image.
         """
 
         command = ' '.join([
@@ -256,12 +275,14 @@ class WhiteTextBroadcast(BaseCardType):
     @staticmethod
     def is_custom_font(font: 'Font') -> bool:
         """
-        Determines whether the given font characteristics constitute a default
-        or custom font.
+        Determines whether the given font characteristics constitute a
+        default or custom font.
         
-        :param      font:   The Font being evaluated.
+        Args:
+            font: The Font being evaluated.
         
-        :returns:   True if a custom font is indicated, False otherwise.
+        Returns:
+            True if a custom font is indicated, False otherwise.
         """
 
         return ((font.file != WhiteTextBroadcast.TITLE_FONT)
@@ -278,14 +299,15 @@ class WhiteTextBroadcast(BaseCardType):
     def is_custom_season_titles(custom_episode_map: bool, 
                                 episode_text_format: str) -> bool:
         """
-        Determines whether the given attributes constitute custom or generic
-        season titles.
+        Determines whether the given attributes constitute custom or
+        generic season titles.
         
-        :param      custom_episode_map:     Whether the EpisodeMap was
-                                            customized.
-        :param      episode_text_format:    The episode text format in use.
+        Args:
+            custom_episode_map: Whether the EpisodeMap was customized.
+            episode_text_format: The episode text format in use.
         
-        :returns:   True if custom season titles are indicated, False otherwise.
+        Returns:
+            False. Custom season titles are not used.
         """
 
         return False
@@ -293,8 +315,8 @@ class WhiteTextBroadcast(BaseCardType):
 
     def create(self) -> None:
         """
-        Make the necessary ImageMagick and system calls to create this object's
-        defined title card.
+        Make the necessary ImageMagick and system calls to create this
+        object's defined title card.
         """
         
         # Add the gradient to the source image (always)

--- a/lyonza/WhiteTextBroadcast.py
+++ b/lyonza/WhiteTextBroadcast.py
@@ -244,6 +244,7 @@ class WhiteTextBroadcast(BaseCardType):
             f'-annotate +100-750 "{self.episode_text}"',
             *self.__series_count_text_effects(),
             f'-annotate +100-750 "{self.episode_text}"',
+            *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
 
@@ -301,9 +302,6 @@ class WhiteTextBroadcast(BaseCardType):
 
         # Add either one or two lines of episode text 
         titled_image = self._add_title_text(gradient_image)
-
-        # Create the output directory and any necessary parents 
-        self.output_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Add episode text 
         self._add_series_count_text_no_season(titled_image)


### PR DESCRIPTION
Should be merged as part of https://github.com/CollinHeist/TitleCardMaker/pull/323 (so that card dimensions can be adjusted for user card types as well).

Also rewrite `azuravian/TitleColorMatch` to not use intermediate/temporary images, instead using a single set of composite commands. Turns card creation from ~8 seconds/card to about 1.5 seconds/card.