### PR TITLE
Update Dawn and Horizon cards

### DIFF
--- a/Supremicus/DawnTitleCard.py
+++ b/Supremicus/DawnTitleCard.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Literal
+from typing import TYPE_CHECKING, Optional, Literal, Union
 
 from pydantic import root_validator
 
@@ -37,14 +37,10 @@ class DawnTitleCard(BaseCardType):
         supports_custom_seasons=True,
         supported_extras=[
             Extra(
-                name='Episode Text Vertical Shift',
-                identifier='episode_text_vertical_shift',
-                description='Vertical Shift for Episode Text',
-                tooltip=(
-                    'Additional vertical shift to apply to the season and episode text. '
-                    'Default is <v>0</v>.<br> If multi-line issues, problem fonts may'
-                    'be fixed by <v>Fix vertical metrics</v> at <v>https://transfonter.org/</v>'
-                ),
+                name='Stroke Text Color',
+                identifier='stroke_color',
+                description='Color to use for the episode & title text stroke',
+                tooltip='Default is <c>black</c>.'
             ),
             Extra(
                 name='Title Text Horizontal Shift',
@@ -56,10 +52,31 @@ class DawnTitleCard(BaseCardType):
                 ),
             ),
             Extra(
-                name='Stroke Text Color',
-                identifier='stroke_color',
-                description='Color to use for the episode & title text stroke',
-                tooltip='Default is <c>black</c>.'
+                name='Episode Text Vertical Shift',
+                identifier='episode_text_vertical_shift',
+                description='Vertical Shift for Episode Text',
+                tooltip=(
+                    'Additional vertical shift to apply to the season and episode text. '
+                    'Default is <v>0</v>.<br> If multi-line issues, problem fonts may'
+                    'be fixed by <v>Fix vertical metrics</v> at <v>https://transfonter.org/</v>'
+                ),
+            ),
+            Extra(
+                name='Episode Text Font',
+                identifier='episode_text_font',
+                description='Font to use for the season and episode text',
+                tooltip=(
+                    'This can be just a file name if the font file is in the '
+                    "Series' source directory, <v>{title_font}</v> to match "
+                    'the Font used for the title text, or a full path to the '
+                    'font file.'
+                ),
+            ),
+            Extra(
+                name='Episode Text Font Size',
+                identifier='episode_text_font_size',
+                description='Size adjustment for the season and episode text',
+                tooltip='Number ≥<v>0.0</v>. Default is <v>1.0</v>.',
             ),
             Extra(
                 name='Episode Text Color',
@@ -121,9 +138,11 @@ class DawnTitleCard(BaseCardType):
     )
 
     class CardModel(BaseCardTypeCustomFontAllText):
-        episode_text_vertical_shift: int = 0
-        title_text_horizontal_shift: int = 0
         stroke_color: str = 'black'
+        title_text_horizontal_shift: int = 0
+        episode_text_vertical_shift: int = 0
+        episode_text_font: Union[Literal['{title_font}'], str, Path] = str(RemoteFile('Supremicus', 'ref/fonts/ExoSoft-Medium.ttf'))
+        episode_text_font_size: float = 1.0
         episode_text_color: Optional[str] = None
         episode_text_stroke_color: Optional[str] = None
         separator: str = '•'
@@ -131,6 +150,23 @@ class DawnTitleCard(BaseCardType):
         crt_overlay: str = None
         crt_state_overlay: bool = False
         omit_gradient: bool = True
+
+        @root_validator(skip_on_failure=True)
+        def validate_episode_text_font_file(cls, values: dict) -> dict:
+            if (etf := values['episode_text_font']) == '{title_font}':
+                values['episode_text_font'] = values['font_file']
+            # Episode text font does not exist, search alongside source image
+            elif not (etf := Path(etf)).exists():
+                if (new_etf := values['source_file'].parent / etf.name).exists():
+                    values['episode_text_font'] = new_etf
+
+            # Verify new specified font file does exist
+            values['episode_text_font'] = Path(values['episode_text_font'])
+            if not Path(values['episode_text_font']).exists():
+                raise ValueError(f'Specified Episode Text Font '
+                                 f'({values["episode_text_font"]}) does not exist')
+
+            return values
 
         @root_validator(skip_on_failure=True)
         def validate_extras(cls, values: dict) -> dict:
@@ -180,10 +216,10 @@ class DawnTitleCard(BaseCardType):
         'episode_text', 'hide_season_text', 'hide_episode_text',
         'line_count', 'font_color', 'font_file', 'font_interline_spacing',
         'font_interword_spacing', 'font_kerning', 'font_size', 'font_stroke_width',
-        'font_vertical_shift', 'episode_text_vertical_shift',
-        'title_text_horizontal_shift', 'stroke_color', 'episode_text_color',
-        'episode_text_stroke_color', 'separator', 'h_align', 'crt_overlay',
-        'crt_state_overlay', 'omit_gradient'
+        'font_vertical_shift', 'stroke_color', 'title_text_horizontal_shift',
+        'episode_text_vertical_shift', 'episode_text_font', 'episode_text_font_size',
+        'episode_text_color', 'episode_text_stroke_color', 'separator', 'h_align',
+        'crt_overlay', 'crt_state_overlay', 'omit_gradient'
     )
 
     def __init__(self,
@@ -204,9 +240,11 @@ class DawnTitleCard(BaseCardType):
             font_vertical_shift: int = 0,
             blur: bool = False,
             grayscale: bool = False,
-            episode_text_vertical_shift: int = 0,
-            title_text_horizontal_shift: int = 0,
             stroke_color: str = 'black',
+            title_text_horizontal_shift: int = 0,
+            episode_text_vertical_shift: int = 0,
+            episode_text_font: Path = EPISODE_TEXT_FONT,
+            episode_text_font_size: float = 1.0,
             episode_text_color: str = None,
             episode_text_stroke_color: str = None,
             separator: str = '•',
@@ -244,9 +282,11 @@ class DawnTitleCard(BaseCardType):
         self.font_vertical_shift = font_vertical_shift
 
         # Optional extras
-        self.episode_text_vertical_shift = episode_text_vertical_shift
-        self.title_text_horizontal_shift = title_text_horizontal_shift
         self.stroke_color = stroke_color
+        self.title_text_horizontal_shift = title_text_horizontal_shift
+        self.episode_text_vertical_shift = episode_text_vertical_shift
+        self.episode_text_font = episode_text_font
+        self.episode_text_font_size = episode_text_font_size
         self.episode_text_color = episode_text_color
         self.episode_text_stroke_color = episode_text_stroke_color
         self.separator = separator
@@ -287,13 +327,13 @@ class DawnTitleCard(BaseCardType):
         stroke_width = 4.0 * self.font_stroke_width
 
         # Base commands
-        size = 60
         base_commands = [
             f'-background transparent',
             f'-kerning 18',
-            f'-pointsize {size:.2f}',
+            f'-pointsize {60 * self.episode_text_font_size}',
             f'-interword-spacing 14.5',
             f'-gravity {gravity}',
+            f'-font "{self.episode_text_font.resolve()}"',
         ]
 
         # Text offsets
@@ -303,7 +343,6 @@ class DawnTitleCard(BaseCardType):
 
         return [
             *base_commands,
-            f'-font "{self.EPISODE_TEXT_FONT.resolve()}"',
             f'-fill {self.episode_text_stroke_color}',
             f'-stroke {self.episode_text_stroke_color}',
             f'-strokewidth {stroke_width}',

--- a/Supremicus/DawnTitleCard.py
+++ b/Supremicus/DawnTitleCard.py
@@ -91,6 +91,12 @@ class DawnTitleCard(BaseCardType):
                 tooltip='Leave blank to match Stroke Text Color.'
             ),
             Extra(
+                name='Episode Text Kerning',
+                identifier='episode_text_kerning',
+                description='Pixel spacing between characters for the season and episode text',
+                tooltip='Number ≥<v>0</v>. Default is <v>18</v> pixels.',
+            ),
+            Extra(
                 name='Separator Character',
                 identifier='separator',
                 description='Character to separate season and episode text',
@@ -145,6 +151,7 @@ class DawnTitleCard(BaseCardType):
         episode_text_font_size: float = 1.0
         episode_text_color: Optional[str] = None
         episode_text_stroke_color: Optional[str] = None
+        episode_text_kerning: int = 18
         separator: str = '•'
         h_align: Literal['left', 'center', 'right'] = 'left'
         crt_overlay: str = None
@@ -218,8 +225,8 @@ class DawnTitleCard(BaseCardType):
         'font_interword_spacing', 'font_kerning', 'font_size', 'font_stroke_width',
         'font_vertical_shift', 'stroke_color', 'title_text_horizontal_shift',
         'episode_text_vertical_shift', 'episode_text_font', 'episode_text_font_size',
-        'episode_text_color', 'episode_text_stroke_color', 'separator', 'h_align',
-        'crt_overlay', 'crt_state_overlay', 'omit_gradient'
+        'episode_text_color', 'episode_text_stroke_color', 'episode_text_kerning', 
+        'separator', 'h_align', 'crt_overlay', 'crt_state_overlay', 'omit_gradient'
     )
 
     def __init__(self,
@@ -247,6 +254,7 @@ class DawnTitleCard(BaseCardType):
             episode_text_font_size: float = 1.0,
             episode_text_color: str = None,
             episode_text_stroke_color: str = None,
+            episode_text_kerning: int = 18,
             separator: str = '•',
             h_align: Literal['left', 'center', 'right'] = 'left',
             crt_overlay:str = None,
@@ -289,6 +297,7 @@ class DawnTitleCard(BaseCardType):
         self.episode_text_font_size = episode_text_font_size
         self.episode_text_color = episode_text_color
         self.episode_text_stroke_color = episode_text_stroke_color
+        self.episode_text_kerning = episode_text_kerning
         self.separator = separator
         self.h_align = h_align
         self.crt_overlay = crt_overlay
@@ -329,7 +338,7 @@ class DawnTitleCard(BaseCardType):
         # Base commands
         base_commands = [
             f'-background transparent',
-            f'-kerning 18',
+            f'-kerning {self.episode_text_kerning}',
             f'-pointsize {60 * self.episode_text_font_size}',
             f'-interword-spacing 14.5',
             f'-gravity {gravity}',

--- a/Supremicus/DawnTitleCard.py
+++ b/Supremicus/DawnTitleCard.py
@@ -6,7 +6,10 @@ from pydantic import root_validator
 from app.schemas.card_type import BaseCardTypeCustomFontAllText
 
 from modules.BaseCardType import (
-    BaseCardType, ImageMagickCommands, Extra, CardDescription
+    BaseCardType,
+    CardDescription,
+    Extra,
+    ImageMagickCommands,
 )
 from modules.Debug import log
 from modules.EpisodeInfo2 import EpisodeInfo
@@ -20,10 +23,10 @@ if TYPE_CHECKING:
 
 class DawnTitleCard(BaseCardType):
     """
-    CardType that produces title cards with left, centered or right aligned
-    text on the bottom. CRT TV overlay (nobezel or bezel) with optional
-    watched style based on Yozora's Retro title card for shows like
-    Stranger Things with a retro theme.
+    CardType that produces title cards with left, centered or right
+    aligned text on the bottom. CRT TV overlay (nobezel or bezel) with
+    optional watched style based on Yozora's Retro title card for shows
+    like Stranger Things with a retro theme.
     """
 
     """API Parameters"""
@@ -31,7 +34,9 @@ class DawnTitleCard(BaseCardType):
         name='Dawn',
         identifier='Supremicus/Dawn',
         example='https://raw.githubusercontent.com/CollinHeist/TitleCardMaker-CardTypes/web-ui/Supremicus/DawnTitleCard.preview.jpg',
-        creators=['Supremicus'],
+        creators=[
+            'Supremicus'
+        ],
         source='remote',
         supports_custom_fonts=True,
         supports_custom_seasons=True,
@@ -39,27 +44,32 @@ class DawnTitleCard(BaseCardType):
             Extra(
                 name='Stroke Text Color',
                 identifier='stroke_color',
-                description='Color to use for the episode & title text stroke',
-                tooltip='Default is <c>black</c>.'
+                description='Color to use for the text stroke',
+                tooltip='Default is <c>black</c>.',
+                default='black',
             ),
             Extra(
                 name='Title Text Horizontal Shift',
                 identifier='title_text_horizontal_shift',
                 description='Horizontal shift for the title text',
                 tooltip=(
-                    'Horizontal shift to apply to title text to align with episode text. '
-                    'Default is <v>0</v>.'
+                    'Horizontal shift to apply to the title text. Default is '
+                    '0. Unit is pixels.'
                 ),
+                default=0,
             ),
             Extra(
                 name='Episode Text Vertical Shift',
                 identifier='episode_text_vertical_shift',
-                description='Vertical Shift for Episode Text',
+                description='Vertical shift for episode text',
                 tooltip=(
-                    'Additional vertical shift to apply to the season and episode text. '
-                    'Default is <v>0</v>.<br> If multi-line issues, problem fonts may'
-                    'be fixed by <v>Fix vertical metrics</v> at <v>https://transfonter.org/</v>'
+                    'Additional vertical shift to apply to the season and '
+                    'episode text. If you encounter multi-line issues, problem '
+                    'fonts maybe fixed by Fix vertical metrics at '
+                    '<v>https://transfonter.org/</v>. Default is <v>0</v>. '
+                    'Unit is pixels.'
                 ),
+                default=0,
             ),
             Extra(
                 name='Episode Text Font',
@@ -77,43 +87,51 @@ class DawnTitleCard(BaseCardType):
                 identifier='episode_text_font_size',
                 description='Size adjustment for the season and episode text',
                 tooltip='Number ≥<v>0.0</v>. Default is <v>1.0</v>.',
+                default=1.0,
             ),
             Extra(
                 name='Episode Text Color',
                 identifier='episode_text_color',
-                description='Color to use separately for the episode text',
-                tooltip='Leave blank to match Title Color.'
+                description='Color to use for the episode text',
+                tooltip='Defaults to match the Title Color.',
             ),
             Extra(
                 name='Episode Stroke Text Color',
                 identifier='episode_text_stroke_color',
-                description='Color to use separately for the episode text stroke',
-                tooltip='Leave blank to match Stroke Text Color.'
+                description='Color to use for the stroke of the episode text',
+                tooltip='Defaults to match the Stroke Text Color.',
             ),
             Extra(
                 name='Episode Text Kerning',
                 identifier='episode_text_kerning',
-                description='Pixel spacing between characters for the season and episode text',
-                tooltip='Number ≥<v>0</v>. Default is <v>18</v> pixels.',
+                description='Spacing between characters for the episode text',
+                tooltip='Default is <v>18</v>. Unit is pixels.',
+                default=18,
             ),
             Extra(
                 name='Separator Character',
                 identifier='separator',
                 description='Character to separate season and episode text',
-                tooltip='Default is <v>•</v>.'
+                tooltip='Default is <v>•</v>.',
+                default='•',
             ),
             Extra(
                 name='Horizontal Alignment',
                 identifier='h_align',
                 description='Horizontal alignment of text',
-                tooltip='Either <v>left</v>, <v>center</v> or <v>right</v>. Default is <v>left</v>.'
+                tooltip=(
+                    'Either <v>left</v>, <v>center</v>, or <v>right</v>. '
+                    'Default is <v>left</v>.'
+                ),
+                default='left',
             ),
             Extra(
                 name='CRT TV Overlay',
                 identifier='crt_overlay',
                 description='CRT TV Overlay Toggle',
                 tooltip=(
-                    'Either <v>nobezel</v> or <v>bezel</v>. Default is <v>None</v>.'
+                    'Whether to display the CRT TV overlay. Either '
+                    '<v>nobezel</v>, or <v>bezel</v>. Default is no overlay.'
                 ),
             ),
             Extra(
@@ -121,25 +139,29 @@ class DawnTitleCard(BaseCardType):
                 identifier='crt_state_overlay',
                 description='CRT TV Overlay Watched-Status Toggle',
                 tooltip=(
-                    'Whether to change the CRT overlay with the watched status of the Episode. '
-                    'Either <v>True</v> or <v>False</v>. Default is <v>False</v>. '
-                    'Will only work if the CRT TV Overlay Toggle is enabled.'
+                    'Whether to change the CRT overlay with the watched status '
+                    'of the Episode. Either <v>True</v> or <v>False</v>. '
+                    'Default is <v>False</v>. Will only work if the CRT TV '
+                    'Overlay Toggle is enabled.'
                 ),
+                default='False',
             ),
             Extra(
                 name='Gradient Omission',
                 identifier='omit_gradient',
                 description='Whether to omit the gradient overlay',
                 tooltip=(
-                    'Either <v>True</v> or <v>False</v>. Set to <v>False</v> if you have '
-                    'trouble reading text on brighter images.<br>Default is <v>True</v>.'
+                    'Either <v>True</v> or <v>False</v>. Set to <v>False</v> '
+                    'if you have trouble reading the text on brighter images.'
+                    'Default is <v>True</v>.'
                 ),
+                default='True',
             ),
         ],
         description=[
             'Produce TitleCards with left, centered or right aligned text on '
-            'the bottom.', 'Optional CRT TV overlay for shows like Stranger '
-            'Things with a retro theme.',
+            'the bottom.', 'An optional CRT TV overlay can be added for shows '
+            'with a retro theme (like Stranger Things)',
         ]
     )
 
@@ -147,19 +169,24 @@ class DawnTitleCard(BaseCardType):
         stroke_color: str = 'black'
         title_text_horizontal_shift: int = 0
         episode_text_vertical_shift: int = 0
-        episode_text_font: Union[Literal['{title_font}'], str, Path] = str(RemoteFile('Supremicus', 'ref/fonts/ExoSoft-Medium.ttf'))
+        episode_text_font: Union[
+            Literal['{title_font}'],
+            str,
+            Path
+        ] = str(RemoteFile('Supremicus', 'ref/fonts/ExoSoft-Medium.ttf'))
         episode_text_font_size: float = 1.0
-        episode_text_color: Optional[str] = None
-        episode_text_stroke_color: Optional[str] = None
+        episode_text_color: str | None = None
+        episode_text_stroke_color: str | None = None
         episode_text_kerning: int = 18
         separator: str = '•'
         h_align: Literal['left', 'center', 'right'] = 'left'
-        crt_overlay: str = None
+        crt_overlay: Literal['nobzel', 'bezel'] | None = None
         crt_state_overlay: bool = False
         omit_gradient: bool = True
 
         @root_validator(skip_on_failure=True)
         def validate_episode_text_font_file(cls, values: dict) -> dict:
+            # Specified as "{title_font}" - use title font file
             if (etf := values['episode_text_font']) == '{title_font}':
                 values['episode_text_font'] = values['font_file']
             # Episode text font does not exist, search alongside source image
@@ -170,8 +197,10 @@ class DawnTitleCard(BaseCardType):
             # Verify new specified font file does exist
             values['episode_text_font'] = Path(values['episode_text_font'])
             if not Path(values['episode_text_font']).exists():
-                raise ValueError(f'Specified Episode Text Font '
-                                 f'({values["episode_text_font"]}) does not exist')
+                raise ValueError(
+                    f'Specified Episode Text Font ('
+                    f'{values["episode_text_font"]}) does not exist'
+                )
 
             return values
 
@@ -257,7 +286,7 @@ class DawnTitleCard(BaseCardType):
             episode_text_kerning: int = 18,
             separator: str = '•',
             h_align: Literal['left', 'center', 'right'] = 'left',
-            crt_overlay:str = None,
+            crt_overlay: Literal['nobzel', 'bezel'] | None = None,
             crt_state_overlay: bool = False,
             omit_gradient: bool = True,
             preferences: Optional['Preferences'] = None,
@@ -459,6 +488,7 @@ class DawnTitleCard(BaseCardType):
 
         if self.crt_overlay is None:
             return []
+
         # Select CRT overlay based on watch status
         if self.crt_overlay == 'nobezel':
             if self.crt_state_overlay and not self.watched:
@@ -517,12 +547,18 @@ class DawnTitleCard(BaseCardType):
 
         # Generic font, reset custom episode text color
         if not custom_font:
-            if 'stroke_color' in extras:
-                extras['stroke_color'] = 'black'
-            if 'title_text_horizontal_shift' in extras:
-                extras['title_text_horizontal_shift'] = 0
-            if 'episode_text_vertical_shift' in extras:
-                extras['episode_text_vertical_shift'] = 0
+            for extra in (
+                'episode_text_color',
+                'episode_text_font',
+                'episode_text_font_size',
+                'episode_text_kerning',
+                'episode_text_stroke_color',
+                'episode_text_vertical_shift',
+                'stroke_color',
+                'title_text_horizontal_shift',
+            ):
+                if extra in extras:
+                    del extras[extra]
 
 
     @staticmethod
@@ -568,10 +604,10 @@ class DawnTitleCard(BaseCardType):
             True if custom season titles are indicated, False otherwise.
         """
 
-        standard_etf = DawnTitleCard.EPISODE_TEXT_FORMAT.upper()
-
-        return (custom_episode_map
-                or episode_text_format.upper() != standard_etf)
+        return (
+            custom_episode_map
+            or episode_text_format != DawnTitleCard.EPISODE_TEXT_FORMAT
+        )
 
 
     @staticmethod
@@ -601,7 +637,7 @@ class DawnTitleCard(BaseCardType):
         object's defined title card.
         """
 
-        command = ' '.join([
+        self.image_magick.run([
             f'convert "{self.source_file.resolve()}"',
             # Resize and optionally blur source image
             *self.resize_and_style,
@@ -619,5 +655,3 @@ class DawnTitleCard(BaseCardType):
             *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
-
-        self.image_magick.run(command)

--- a/Supremicus/DawnTitleCard.py
+++ b/Supremicus/DawnTitleCard.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Literal
 
+from pydantic import root_validator
+
 from app.schemas.card_type import BaseCardTypeCustomFontAllText
 
 from modules.BaseCardType import (
@@ -60,6 +62,18 @@ class DawnTitleCard(BaseCardType):
                 tooltip='Default is <c>black</c>.'
             ),
             Extra(
+                name='Episode Text Color',
+                identifier='episode_text_color',
+                description='Color to use separately for the episode text',
+                tooltip='Leave blank to match Title Color.'
+            ),
+            Extra(
+                name='Episode Stroke Text Color',
+                identifier='episode_text_stroke_color',
+                description='Color to use separately for the episode text stroke',
+                tooltip='Leave blank to match Stroke Text Color.'
+            ),
+            Extra(
                 name='Separator Character',
                 identifier='separator',
                 description='Character to separate season and episode text',
@@ -110,11 +124,23 @@ class DawnTitleCard(BaseCardType):
         episode_text_vertical_shift: int = 0
         title_text_horizontal_shift: int = 0
         stroke_color: str = 'black'
+        episode_text_color: Optional[str] = None
+        episode_text_stroke_color: Optional[str] = None
         separator: str = '•'
         h_align: Literal['left', 'center', 'right'] = 'left'
         crt_overlay: str = None
         crt_state_overlay: bool = False
         omit_gradient: bool = True
+
+        @root_validator(skip_on_failure=True)
+        def validate_extras(cls, values: dict) -> dict:
+            # Convert None colors to the default font color
+            if values['episode_text_color'] is None:
+                values['episode_text_color'] = values['font_color']
+            if values['episode_text_stroke_color'] is None:
+                values['episode_text_stroke_color'] = values['stroke_color']
+
+            return values
 
     """Characteristics for title splitting by this class"""
     TITLE_CHARACTERISTICS: SplitCharacteristics = {
@@ -155,8 +181,9 @@ class DawnTitleCard(BaseCardType):
         'line_count', 'font_color', 'font_file', 'font_interline_spacing',
         'font_interword_spacing', 'font_kerning', 'font_size', 'font_stroke_width',
         'font_vertical_shift', 'episode_text_vertical_shift',
-        'title_text_horizontal_shift', 'stroke_color', 'separator', 'h_align',
-        'crt_overlay', 'crt_state_overlay', 'omit_gradient'
+        'title_text_horizontal_shift', 'stroke_color', 'episode_text_color',
+        'episode_text_stroke_color', 'separator', 'h_align', 'crt_overlay',
+        'crt_state_overlay', 'omit_gradient'
     )
 
     def __init__(self,
@@ -180,6 +207,8 @@ class DawnTitleCard(BaseCardType):
             episode_text_vertical_shift: int = 0,
             title_text_horizontal_shift: int = 0,
             stroke_color: str = 'black',
+            episode_text_color: str = None,
+            episode_text_stroke_color: str = None,
             separator: str = '•',
             h_align: Literal['left', 'center', 'right'] = 'left',
             crt_overlay:str = None,
@@ -218,6 +247,8 @@ class DawnTitleCard(BaseCardType):
         self.episode_text_vertical_shift = episode_text_vertical_shift
         self.title_text_horizontal_shift = title_text_horizontal_shift
         self.stroke_color = stroke_color
+        self.episode_text_color = episode_text_color
+        self.episode_text_stroke_color = episode_text_stroke_color
         self.separator = separator
         self.h_align = h_align
         self.crt_overlay = crt_overlay
@@ -273,12 +304,12 @@ class DawnTitleCard(BaseCardType):
         return [
             *base_commands,
             f'-font "{self.EPISODE_TEXT_FONT.resolve()}"',
-            f'-fill {self.stroke_color}',
-            f'-stroke {self.stroke_color}',
+            f'-fill {self.episode_text_stroke_color}',
+            f'-stroke {self.episode_text_stroke_color}',
             f'-strokewidth {stroke_width}',
             f'-annotate {x:+}{y:+} "{index_text}"',
-            f'-fill "{self.font_color}"',
-            f'-stroke "{self.font_color}"',
+            f'-fill "{self.episode_text_color}"',
+            f'-stroke "{self.episode_text_color}"',
             f'-strokewidth 0',
             f'-annotate {x:+}{y:+} "{index_text}"',
         ]

--- a/Supremicus/HorizonTitleCard.py
+++ b/Supremicus/HorizonTitleCard.py
@@ -84,6 +84,12 @@ class HorizonTitleCard(BaseCardType):
                 tooltip='Leave blank to match Stroke Text Color.'
             ),
             Extra(
+                name='Episode Text Kerning',
+                identifier='episode_text_kerning',
+                description='Pixel spacing between characters for the season and episode text',
+                tooltip='Number ≥<v>0</v>. Default is <v>18</v> pixels.',
+            ),
+            Extra(
                 name='Separator Character',
                 identifier='separator',
                 description='Character to separate season and episode text',
@@ -165,6 +171,7 @@ class HorizonTitleCard(BaseCardType):
         episode_text_font_size: float = 1.0
         episode_text_color: Optional[str] = None
         episode_text_stroke_color: Optional[str] = None
+        episode_text_kerning: int = 18
         separator: str = '•'
         h_align: Literal['left', 'right'] = 'left'
         symbol: Optional[str] = None
@@ -253,8 +260,9 @@ class HorizonTitleCard(BaseCardType):
         'font_interword_spacing', 'font_kerning', 'font_size', 'font_stroke_width',
         'font_vertical_shift', 'stroke_color', 'episode_text_vertical_shift',
         'episode_text_font', 'episode_text_font_size', 'episode_text_color',
-        'episode_text_stroke_color', 'separator', 'h_align', 'symbol', 'logo',
-        'alignment_overlay', 'crt_overlay', 'crt_state_overlay', 'omit_gradient'
+        'episode_text_stroke_color', 'episode_text_kerning', 'separator', 'h_align',
+        'symbol', 'logo', 'alignment_overlay', 'crt_overlay', 'crt_state_overlay',
+        'omit_gradient'
     )
 
     def __init__(self,
@@ -281,6 +289,7 @@ class HorizonTitleCard(BaseCardType):
             episode_text_font_size: float = 1.0,
             episode_text_color: str = None,
             episode_text_stroke_color: str = None,
+            episode_text_kerning: int = 18,
             separator: str = '•',
             h_align: Literal['left', 'right'] = 'left',
             logo_file: Optional[Path] = None,
@@ -325,6 +334,7 @@ class HorizonTitleCard(BaseCardType):
         self.episode_text_font_size = episode_text_font_size
         self.episode_text_color = episode_text_color
         self.episode_text_stroke_color = episode_text_stroke_color
+        self.episode_text_kerning = episode_text_kerning
         self.separator = separator
         self.h_align = h_align
         self.logo = logo_file
@@ -357,7 +367,7 @@ class HorizonTitleCard(BaseCardType):
         # Base commands
         base_commands = [
             f'-background transparent',
-            f'-kerning 18',
+            f'-kerning {self.episode_text_kerning}',
             f'-pointsize {60 * self.episode_text_font_size}',
             f'-interword-spacing 14.5',
             f'-gravity north',

--- a/Supremicus/HorizonTitleCard.py
+++ b/Supremicus/HorizonTitleCard.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Literal
 
+from pydantic import root_validator
+
 from app.schemas.card_type import BaseCardTypeCustomFontAllText
 
 from modules.BaseCardType import (
@@ -51,6 +53,18 @@ class HorizonTitleCard(BaseCardType):
                 identifier='stroke_color',
                 description='Color to use for the episode & title text stroke',
                 tooltip='Default is <c>black</c>.'
+            ),
+            Extra(
+                name='Episode Text Color',
+                identifier='episode_text_color',
+                description='Color to use separately for the episode text',
+                tooltip='Leave blank to match Title Color.'
+            ),
+            Extra(
+                name='Episode Stroke Text Color',
+                identifier='episode_text_stroke_color',
+                description='Color to use separately for the episode text stroke',
+                tooltip='Leave blank to match Stroke Text Color.'
             ),
             Extra(
                 name='Separator Character',
@@ -130,6 +144,8 @@ class HorizonTitleCard(BaseCardType):
     class CardModel(BaseCardTypeCustomFontAllText):
         episode_text_vertical_shift: int = 0
         stroke_color: str = 'black'
+        episode_text_color: Optional[str] = None
+        episode_text_stroke_color: Optional[str] = None
         separator: str = '•'
         h_align: Literal['left', 'right'] = 'left'
         symbol: Optional[str] = None
@@ -138,6 +154,16 @@ class HorizonTitleCard(BaseCardType):
         crt_overlay: str = None
         crt_state_overlay: bool = False
         omit_gradient: bool = True
+
+        @root_validator(skip_on_failure=True)
+        def validate_extras(cls, values: dict) -> dict:
+            # Convert None colors to the default font color
+            if values['episode_text_color'] is None:
+                values['episode_text_color'] = values['font_color']
+            if values['episode_text_stroke_color'] is None:
+                values['episode_text_stroke_color'] = values['stroke_color']
+
+            return values
 
     """Characteristics for title splitting by this class"""
     TITLE_CHARACTERISTICS: SplitCharacteristics = {
@@ -190,8 +216,9 @@ class HorizonTitleCard(BaseCardType):
         'line_count', 'font_color', 'font_file', 'font_interline_spacing',
         'font_interword_spacing', 'font_kerning', 'font_size', 'font_stroke_width',
         'font_vertical_shift', 'episode_text_vertical_shift', 'stroke_color',
-        'separator', 'h_align', 'symbol', 'logo', 'alignment_overlay',
-        'crt_overlay', 'crt_state_overlay', 'omit_gradient'
+        'episode_text_color', 'episode_text_stroke_color', 'separator', 'h_align', 
+        'symbol', 'logo', 'alignment_overlay', 'crt_overlay', 'crt_state_overlay',
+        'omit_gradient'
     )
 
     def __init__(self,
@@ -214,6 +241,8 @@ class HorizonTitleCard(BaseCardType):
             grayscale: bool = False,
             episode_text_vertical_shift: int = 0,
             stroke_color: str = 'black',
+            episode_text_color: str = None,
+            episode_text_stroke_color: str = None,
             separator: str = '•',
             h_align: Literal['left', 'right'] = 'left',
             logo_file: Optional[Path] = None,
@@ -254,6 +283,8 @@ class HorizonTitleCard(BaseCardType):
         # Optional extras
         self.episode_text_vertical_shift = episode_text_vertical_shift
         self.stroke_color = stroke_color
+        self.episode_text_color = episode_text_color
+        self.episode_text_stroke_color = episode_text_stroke_color
         self.separator = separator
         self.h_align = h_align
         self.logo = logo_file
@@ -301,12 +332,12 @@ class HorizonTitleCard(BaseCardType):
 
         return [
             *base_commands,
-            f'-fill {self.stroke_color}',
-            f'-stroke {self.stroke_color}',
+            f'-fill {self.episode_text_stroke_color}',
+            f'-stroke {self.episode_text_stroke_color}',
             f'-strokewidth {stroke_width}',
             f'-annotate {x:+}{y:+} "{index_text}"',
-            f'-fill "{self.font_color}"',
-            f'-stroke "{self.font_color}"',
+            f'-fill "{self.episode_text_color}"',
+            f'-stroke "{self.episode_text_color}"',
             f'-strokewidth 0',
             f'-annotate {x:+}{y:+} "{index_text}"',
         ]

--- a/Supremicus/HorizonTitleCard.py
+++ b/Supremicus/HorizonTitleCard.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Literal
+from typing import TYPE_CHECKING, Optional, Literal, Union
 
 from pydantic import root_validator
 
@@ -38,6 +38,12 @@ class HorizonTitleCard(BaseCardType):
         supports_custom_seasons=True,
         supported_extras=[
             Extra(
+                name='Stroke Text Color',
+                identifier='stroke_color',
+                description='Color to use for the episode & title text stroke',
+                tooltip='Default is <c>black</c>.'
+            ),
+            Extra(
                 name='Episode Text Vertical Shift',
                 identifier='episode_text_vertical_shift',
                 description='Vertical Shift for Episode Text.',
@@ -49,10 +55,21 @@ class HorizonTitleCard(BaseCardType):
                 ),
             ),
             Extra(
-                name='Stroke Text Color',
-                identifier='stroke_color',
-                description='Color to use for the episode & title text stroke',
-                tooltip='Default is <c>black</c>.'
+                name='Episode Text Font',
+                identifier='episode_text_font',
+                description='Font to use for the season and episode text',
+                tooltip=(
+                    'This can be just a file name if the font file is in the '
+                    "Series' source directory, <v>{title_font}</v> to match "
+                    'the Font used for the title text, or a full path to the '
+                    'font file.'
+                ),
+            ),
+            Extra(
+                name='Episode Text Font Size',
+                identifier='episode_text_font_size',
+                description='Size adjustment for the season and episode text',
+                tooltip='Number ≥<v>0.0</v>. Default is <v>1.0</v>.',
             ),
             Extra(
                 name='Episode Text Color',
@@ -142,8 +159,10 @@ class HorizonTitleCard(BaseCardType):
     )
 
     class CardModel(BaseCardTypeCustomFontAllText):
-        episode_text_vertical_shift: int = 0
         stroke_color: str = 'black'
+        episode_text_vertical_shift: int = 0
+        episode_text_font: Union[Literal['{title_font}'], str, Path] = str(RemoteFile('Supremicus', 'ref/fonts/ExoSoft-Medium.ttf'))
+        episode_text_font_size: float = 1.0
         episode_text_color: Optional[str] = None
         episode_text_stroke_color: Optional[str] = None
         separator: str = '•'
@@ -154,6 +173,23 @@ class HorizonTitleCard(BaseCardType):
         crt_overlay: str = None
         crt_state_overlay: bool = False
         omit_gradient: bool = True
+
+        @root_validator(skip_on_failure=True)
+        def validate_episode_text_font_file(cls, values: dict) -> dict:
+            if (etf := values['episode_text_font']) == '{title_font}':
+                values['episode_text_font'] = values['font_file']
+            # Episode text font does not exist, search alongside source image
+            elif not (etf := Path(etf)).exists():
+                if (new_etf := values['source_file'].parent / etf.name).exists():
+                    values['episode_text_font'] = new_etf
+
+            # Verify new specified font file does exist
+            values['episode_text_font'] = Path(values['episode_text_font'])
+            if not Path(values['episode_text_font']).exists():
+                raise ValueError(f'Specified Episode Text Font '
+                                 f'({values["episode_text_font"]}) does not exist')
+
+            return values
 
         @root_validator(skip_on_failure=True)
         def validate_extras(cls, values: dict) -> dict:
@@ -215,10 +251,10 @@ class HorizonTitleCard(BaseCardType):
         'episode_prefix', 'episode_text', 'hide_season_text', 'hide_episode_text',
         'line_count', 'font_color', 'font_file', 'font_interline_spacing',
         'font_interword_spacing', 'font_kerning', 'font_size', 'font_stroke_width',
-        'font_vertical_shift', 'episode_text_vertical_shift', 'stroke_color',
-        'episode_text_color', 'episode_text_stroke_color', 'separator', 'h_align', 
-        'symbol', 'logo', 'alignment_overlay', 'crt_overlay', 'crt_state_overlay',
-        'omit_gradient'
+        'font_vertical_shift', 'stroke_color', 'episode_text_vertical_shift',
+        'episode_text_font', 'episode_text_font_size', 'episode_text_color',
+        'episode_text_stroke_color', 'separator', 'h_align', 'symbol', 'logo',
+        'alignment_overlay', 'crt_overlay', 'crt_state_overlay', 'omit_gradient'
     )
 
     def __init__(self,
@@ -239,8 +275,10 @@ class HorizonTitleCard(BaseCardType):
             font_vertical_shift: int = 0,
             blur: bool = False,
             grayscale: bool = False,
-            episode_text_vertical_shift: int = 0,
             stroke_color: str = 'black',
+            episode_text_vertical_shift: int = 0,
+            episode_text_font: Path = EPISODE_TEXT_FONT,
+            episode_text_font_size: float = 1.0,
             episode_text_color: str = None,
             episode_text_stroke_color: str = None,
             separator: str = '•',
@@ -281,8 +319,10 @@ class HorizonTitleCard(BaseCardType):
         self.font_vertical_shift = font_vertical_shift
 
         # Optional extras
-        self.episode_text_vertical_shift = episode_text_vertical_shift
         self.stroke_color = stroke_color
+        self.episode_text_vertical_shift = episode_text_vertical_shift
+        self.episode_text_font = episode_text_font
+        self.episode_text_font_size = episode_text_font_size
         self.episode_text_color = episode_text_color
         self.episode_text_stroke_color = episode_text_stroke_color
         self.separator = separator
@@ -315,14 +355,13 @@ class HorizonTitleCard(BaseCardType):
         stroke_width = 4.0 * self.font_stroke_width
 
         # Base commands
-        size = 60
         base_commands = [
             f'-background transparent',
             f'-kerning 18',
-            f'-pointsize {size:.2f}',
+            f'-pointsize {60 * self.episode_text_font_size}',
             f'-interword-spacing 14.5',
             f'-gravity north',
-            f'-font "{self.EPISODE_TEXT_FONT.resolve()}"',
+            f'-font "{self.episode_text_font.resolve()}"',
         ]
 
         # Text offsets

--- a/Supremicus/HorizonTitleCard.py
+++ b/Supremicus/HorizonTitleCard.py
@@ -6,7 +6,10 @@ from pydantic import root_validator
 from app.schemas.card_type import BaseCardTypeCustomFontAllText
 
 from modules.BaseCardType import (
-    BaseCardType, ImageMagickCommands, Extra, CardDescription
+    BaseCardType,
+    CardDescription,
+    Extra,
+    ImageMagickCommands,
 )
 from modules.Debug import log
 from modules.EpisodeInfo2 import EpisodeInfo
@@ -32,7 +35,9 @@ class HorizonTitleCard(BaseCardType):
         name='Horizon',
         identifier='Supremicus/Horizon',
         example='https://raw.githubusercontent.com/CollinHeist/TitleCardMaker-CardTypes/web-ui/Supremicus/HorizonTitleCard.preview.jpg',
-        creators=['Supremicus'],
+        creators=[
+            'Supremicus'
+        ],
         source='remote',
         supports_custom_fonts=True,
         supports_custom_seasons=True,
@@ -40,19 +45,22 @@ class HorizonTitleCard(BaseCardType):
             Extra(
                 name='Stroke Text Color',
                 identifier='stroke_color',
-                description='Color to use for the episode & title text stroke',
-                tooltip='Default is <c>black</c>.'
+                description='Color to use for the text stroke',
+                tooltip='Default is <c>black</c>.',
+                default='black'
             ),
             Extra(
                 name='Episode Text Vertical Shift',
                 identifier='episode_text_vertical_shift',
-                description='Vertical Shift for Episode Text.',
+                description='Vertical shift for episode text',
                 tooltip=(
                     'Additional vertical shift to apply to the season and '
-                    'episode text. Default is <v>0</v>.<br> If multi-line '
-                    'issues, problem fonts may be fixed by fix vertical '
-                    'metrics at <v>https://transfonter.org/</v>.'
+                    'episode text. If you encounter multi-line issues, problem '
+                    'fonts maybe fixed by Fix vertical metrics at '
+                    '<v>https://transfonter.org/</v>. Default is <v>0</v>. '
+                    'Unit is pixels.'
                 ),
+                default=0,
             ),
             Extra(
                 name='Episode Text Font',
@@ -70,39 +78,43 @@ class HorizonTitleCard(BaseCardType):
                 identifier='episode_text_font_size',
                 description='Size adjustment for the season and episode text',
                 tooltip='Number ≥<v>0.0</v>. Default is <v>1.0</v>.',
+                default=1.0,
             ),
             Extra(
                 name='Episode Text Color',
                 identifier='episode_text_color',
-                description='Color to use separately for the episode text',
-                tooltip='Leave blank to match Title Color.'
+                description='Color to use for the episode text',
+                tooltip='Defaults to match the Title Color.',
             ),
             Extra(
                 name='Episode Stroke Text Color',
                 identifier='episode_text_stroke_color',
-                description='Color to use separately for the episode text stroke',
-                tooltip='Leave blank to match Stroke Text Color.'
+                description='Color to use for the stroke of the episode text',
+                tooltip='Defaults to match the Stroke Text Color.',
             ),
             Extra(
                 name='Episode Text Kerning',
                 identifier='episode_text_kerning',
-                description='Pixel spacing between characters for the season and episode text',
-                tooltip='Number ≥<v>0</v>. Default is <v>18</v> pixels.',
+                description='Spacing between characters for the episode text',
+                tooltip='Default is <v>18</v>. Unit is pixels.',
+                default=18,
             ),
             Extra(
                 name='Separator Character',
                 identifier='separator',
                 description='Character to separate season and episode text',
-                tooltip='Default is <v>•</v>.'
+                tooltip='Default is <v>•</v>.',
+                default='•',
             ),
             Extra(
                 name='Horizontal Alignment',
                 identifier='h_align',
-                description='Horizontal alignment of the text and symbol',
+                description='Horizontal alignment of text',
                 tooltip=(
-                    'Either <v>left</v> or <v>right</v>. Default is '
-                    '<v>left</v>.'
-                )
+                    'Either <v>left</v>, <v>center</v>, or <v>right</v>. '
+                    'Default is <v>left</v>.'
+                ),
+                default='left',
             ),
             Extra(
                 name='Symbol',
@@ -111,7 +123,7 @@ class HorizonTitleCard(BaseCardType):
                 tooltip=(
                     'Either <v>acolyte</v>, <v>ahsoka</v>, <v>andor</v>, '
                     '<v>bobafett<v>, <v>mandalorian</v>, <v>obiwan</v>, or '
-                    '<v>witcher</v> to use a built-in symbol, or <v>logo</v> '
+                    '<v>witcher</v> to use a built-in symbol; or <v>logo</v> '
                     'to use the Series logo.'
                 ),
             ),
@@ -120,8 +132,8 @@ class HorizonTitleCard(BaseCardType):
                 identifier='crt_overlay',
                 description='CRT TV Overlay Toggle',
                 tooltip=(
-                    'Either <v>nobezel</v> or <v>bezel</v>. Default is '
-                    '<v>None</v>.'
+                    'Whether to display the CRT TV overlay. Either '
+                    '<v>nobezel</v>, or <v>bezel</v>. Default is no overlay.'
                 ),
             ),
             Extra(
@@ -134,6 +146,7 @@ class HorizonTitleCard(BaseCardType):
                     'Default is <v>False</v>. Will only work if the CRT TV '
                     'Overlay Toggle is enabled.'
                 ),
+                default='False',
             ),
             Extra(
                 name='Gradient Omission',
@@ -141,9 +154,10 @@ class HorizonTitleCard(BaseCardType):
                 description='Whether to omit the gradient overlay',
                 tooltip=(
                     'Either <v>True</v> or <v>False</v>. Set to <v>False</v> '
-                    'if you have trouble reading text on brighter images. '
+                    'if you have trouble reading the text on brighter images.'
                     'Default is <v>True</v>.'
                 ),
+                default='True',
             ),
             Extra(
                 name='Alignment Overlay',
@@ -155,6 +169,7 @@ class HorizonTitleCard(BaseCardType):
                     'guiding lines every 10 pixels. Either <v>True</v> or '
                     '<v>False</v>. Default is <v>False</v>.'
                 ),
+                default='False',
             ),
         ],
         description=[
@@ -167,17 +182,24 @@ class HorizonTitleCard(BaseCardType):
     class CardModel(BaseCardTypeCustomFontAllText):
         stroke_color: str = 'black'
         episode_text_vertical_shift: int = 0
-        episode_text_font: Union[Literal['{title_font}'], str, Path] = str(RemoteFile('Supremicus', 'ref/fonts/ExoSoft-Medium.ttf'))
+        episode_text_font: Union[
+            Literal['{title_font}'],
+            str,
+            Path,
+        ] = str(RemoteFile('Supremicus', 'ref/fonts/ExoSoft-Medium.ttf'))
         episode_text_font_size: float = 1.0
-        episode_text_color: Optional[str] = None
-        episode_text_stroke_color: Optional[str] = None
+        episode_text_color: str | None = None
+        episode_text_stroke_color: str | None = None
         episode_text_kerning: int = 18
         separator: str = '•'
         h_align: Literal['left', 'right'] = 'left'
-        symbol: Optional[str] = None
+        symbol: Literal[
+            'acolyte', 'ashoka', 'andor', 'bobafett', 'mandalorian', 'obiwan',
+            'witcher', 'logo',
+        ] | None = None
         logo_file: Path
         alignment_overlay: bool = False
-        crt_overlay: str = None
+        crt_overlay: Literal['nobzel', 'bezel'] | None = None
         crt_state_overlay: bool = False
         omit_gradient: bool = True
 
@@ -193,8 +215,10 @@ class HorizonTitleCard(BaseCardType):
             # Verify new specified font file does exist
             values['episode_text_font'] = Path(values['episode_text_font'])
             if not Path(values['episode_text_font']).exists():
-                raise ValueError(f'Specified Episode Text Font '
-                                 f'({values["episode_text_font"]}) does not exist')
+                raise ValueError(
+                    f'Specified Episode Text Font '
+                    f'({values["episode_text_font"]}) does not exist'
+                )
 
             return values
 
@@ -218,7 +242,7 @@ class HorizonTitleCard(BaseCardType):
     """Characteristics of the default title font"""
     TITLE_FONT = str(RemoteFile('Supremicus', 'ref/fonts/HelveticaNeue-Bold.ttf'))
     TITLE_COLOR = 'white'
-    FONT_REPLACEMENTS = {}
+    FONT_REPLACEMENTS: dict[str, str] = {}
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = True
@@ -293,7 +317,16 @@ class HorizonTitleCard(BaseCardType):
             separator: str = '•',
             h_align: Literal['left', 'right'] = 'left',
             logo_file: Optional[Path] = None,
-            symbol: str = None,
+            symbol: None | Literal[
+                'acolyte',
+                'ashoka',
+                'andor',
+                'bobafett',
+                'mandalorian',
+                'obiwan',
+                'witcher',
+                'logo',
+            ] = None,
             alignment_overlay: bool = False,
             crt_overlay:str = None,
             crt_state_overlay: bool = False,
@@ -570,10 +603,16 @@ class HorizonTitleCard(BaseCardType):
 
         # Generic font, reset custom episode text color
         if not custom_font:
-            if 'stroke_color' in extras:
-                extras['stroke_color'] = 'black'
-            if 'episode_text_vertical_shift' in extras:
-                extras['episode_text_vertical_shift'] = 0
+            for extra in (
+                'stroke_color',
+                'episode_text_color',
+                'episode_text_kerning',
+                'episode_text_stroke_color',
+                'episode_text_font',
+                'episode_text_vertical_shift',
+            ):
+                if extra in extras:
+                    del extras[extra]
 
 
     @staticmethod
@@ -617,9 +656,10 @@ class HorizonTitleCard(BaseCardType):
             True if custom season titles are indicated, False otherwise.
         """
 
-        return (custom_episode_map
-                or episode_text_format.upper() != \
-                    HorizonTitleCard.EPISODE_TEXT_FORMAT.upper())
+        return (
+            custom_episode_map
+            or episode_text_format != HorizonTitleCard.EPISODE_TEXT_FORMAT
+        )
 
 
     @staticmethod
@@ -649,7 +689,7 @@ class HorizonTitleCard(BaseCardType):
         object's defined title card.
         """
 
-        command = ' '.join([
+        self.image_magick.run([
             f'convert "{self.source_file.resolve()}"',
             # Resize and optionally blur source image
             *self.resize_and_style,
@@ -671,5 +711,3 @@ class HorizonTitleCard(BaseCardType):
             *self.resize_output,
             f'"{self.output_file.resolve()}"',
         ])
-
-        self.image_magick.run(command)

--- a/Supremicus/README.md
+++ b/Supremicus/README.md
@@ -8,9 +8,11 @@ Below is a table of all valid series [extras](https://github.com/CollinHeist/Tit
 
 | Label | Default Value | Description |
 | :---: | :---: | :--- |
-| `episode_text_vertical_shift` | `0` | How many pixels to vertically shift the episode text |
-| `title_text_horizontal_shift` | `0` | How many pixels to horizontally shift the title text |
 | `stroke_color` | `black` | Stroke color of episode and title text |
+| `title_text_horizontal_shift` | `0` | How many pixels to horizontally shift the title text |
+| `episode_text_vertical_shift` | `0` | How many pixels to vertically shift the episode text |
+| `episode_text_font` | `Default` | Font file to use for the episode text |
+| `episode_text_font_size` | `1.0` | Scalar of the size of the episode text |
 | `episode_text_color` | `None` | Color to use separately for the episode text |
 | `episode_text_stroke_color` | `None` | Color to use separately for the episode text stroke |
 | `separator` | `•` | Character to separate the season and episode text |
@@ -40,8 +42,10 @@ Below is a table of all valid series [extras](https://github.com/CollinHeist/Tit
 
 | Label | Default Value | Description |
 | :---: | :---: | :--- |
-| `episode_text_vertical_shift` | `0` | How many pixels to vertically shift the episode text |
 | `stroke_color` | `black` | Stroke color of episode and title text |
+| `episode_text_vertical_shift` | `0` | How many pixels to vertically shift the episode text |
+| `episode_text_font` | `Default` | Font file to use for the episode text |
+| `episode_text_font_size` | `1.0` | Scalar of the size of the episode text |
 | `episode_text_color` | `None` | Color to use separately for the episode text |
 | `episode_text_stroke_color` | `None` | Color to use separately for the episode text stroke |
 | `separator` | `•` | Character to separate the season and episode text |

--- a/Supremicus/README.md
+++ b/Supremicus/README.md
@@ -11,6 +11,8 @@ Below is a table of all valid series [extras](https://github.com/CollinHeist/Tit
 | `episode_text_vertical_shift` | `0` | How many pixels to vertically shift the episode text |
 | `title_text_horizontal_shift` | `0` | How many pixels to horizontally shift the title text |
 | `stroke_color` | `black` | Stroke color of episode and title text |
+| `episode_text_color` | `None` | Color to use separately for the episode text |
+| `episode_text_stroke_color` | `None` | Color to use separately for the episode text stroke |
 | `separator` | `•` | Character to separate the season and episode text |
 | `h_align` | `left` | Horizontal alignment. `left`, `center` or `right` |
 | `crt_overlay` | `None` | Enable CRT TV Overlay `none`, `nobezel` or `bezel` |
@@ -40,6 +42,8 @@ Below is a table of all valid series [extras](https://github.com/CollinHeist/Tit
 | :---: | :---: | :--- |
 | `episode_text_vertical_shift` | `0` | How many pixels to vertically shift the episode text |
 | `stroke_color` | `black` | Stroke color of episode and title text |
+| `episode_text_color` | `None` | Color to use separately for the episode text |
+| `episode_text_stroke_color` | `None` | Color to use separately for the episode text stroke |
 | `separator` | `•` | Character to separate the season and episode text |
 | `h_align` | `left` | Horizontal alignment. `left` or `right` |
 | `symbol` | `None` | Custom symbol to use<br>Built-in: `acolyte`, `ahsoka`, `andor`, `bobafett`, `mandalorian`, `obiwan`, `witcher`<br>Custom: `logo` uses *source/show/logo.png* |

--- a/Supremicus/README.md
+++ b/Supremicus/README.md
@@ -15,6 +15,7 @@ Below is a table of all valid series [extras](https://github.com/CollinHeist/Tit
 | `episode_text_font_size` | `1.0` | Scalar of the size of the episode text |
 | `episode_text_color` | `None` | Color to use separately for the episode text |
 | `episode_text_stroke_color` | `None` | Color to use separately for the episode text stroke |
+| `episode_text_kerning` | `18` | Pixel spacing between characters for the episode text |
 | `separator` | `•` | Character to separate the season and episode text |
 | `h_align` | `left` | Horizontal alignment. `left`, `center` or `right` |
 | `crt_overlay` | `None` | Enable CRT TV Overlay `none`, `nobezel` or `bezel` |
@@ -48,6 +49,7 @@ Below is a table of all valid series [extras](https://github.com/CollinHeist/Tit
 | `episode_text_font_size` | `1.0` | Scalar of the size of the episode text |
 | `episode_text_color` | `None` | Color to use separately for the episode text |
 | `episode_text_stroke_color` | `None` | Color to use separately for the episode text stroke |
+| `episode_text_kerning` | `18` | Pixel spacing between characters for the episode text |
 | `separator` | `•` | Character to separate the season and episode text |
 | `h_align` | `left` | Horizontal alignment. `left` or `right` |
 | `symbol` | `None` | Custom symbol to use<br>Built-in: `acolyte`, `ahsoka`, `andor`, `bobafett`, `mandalorian`, `obiwan`, `witcher`<br>Custom: `logo` uses *source/show/logo.png* |

--- a/cards.json
+++ b/cards.json
@@ -426,7 +426,7 @@
                 "default": "True"
             }
         ],
-        "hash": "7b4e4c497c2c47ba3d5f587bb8152b8d"
+        "hash": "533d84e83ff1a31bb6916c5d886b860d"
     },
     {
         "name": "Horizon",

--- a/cards.json
+++ b/cards.json
@@ -329,7 +329,7 @@
         "identifier": "Supremicus/DawnTitleCard",
         "description": [
             "Produce TitleCards with left, centered or right aligned text on the bottom.",
-            "Optional CRT TV overlay for shows like Stranger Things with a retro theme."
+            "An optional CRT TV overlay can be added for shows with a retro theme (like Stranger Things)"
         ],
         "example": "https://raw.githubusercontent.com/CollinHeist/TitleCardMaker-CardTypes/web-ui/Supremicus/DawnTitleCard.preview.jpg",
         "creators": [
@@ -339,55 +339,94 @@
         "supports_custom_seasons": true,
         "supported_extras": [
             {
-                "name": "Episode Text Vertical Shift",
-                "identifier": "episode_text_vertical_shift",
-                "description": "Vertical Shift for Episode Text",
-                "tooltip": "Additional vertical shift to apply to the season and episode text. Default is <v>0</v>.<br> If multi-line issues, problem fonts may be fixed by <v>Fix vertical metrics</v> at <v>https://transfonter.org/</v>"
+                "name": "Stroke Text Color",
+                "identifier": "stroke_color",
+                "description": "Color to use for the text stroke",
+                "tooltip": "Default is <c>black</c>.",
+                "default": "black"
             },
             {
                 "name": "Title Text Horizontal Shift",
                 "identifier": "title_text_horizontal_shift",
                 "description": "Horizontal shift for the title text",
-                "tooltip": "Horizontal shift to apply to title text to align with episode text. Default is <v>0</v>."
+                "tooltip": "Horizontal shift to apply to the title text. Default is 0. Unit is pixels.",
+                "default": 0
             },
             {
-                "name": "Stroke Text Color",
-                "identifier": "stroke_color",
-                "description": "Color to use for the episode & title text stroke",
-                "tooltip": "Default is <c>black</c>."
+                "name": "Episode Text Vertical Shift",
+                "identifier": "episode_text_vertical_shift",
+                "description": "Vertical Shift for Episode Text",
+                "tooltip": "Additional vertical shift to apply to the season and episode text. If you encounter multi-line issues, problem fonts maybe fixed by Fix vertical metrics at <v>https://transfonter.org/</v>. Default is <v>0</v>. Unit is pixels.",
+                "default": 0
+            },
+            {
+                "name": "Episode Text Font",
+                "identifier": "episode_text_font",
+                "description": "Font to use for the season and episode text",
+                "tooltip": "This can be just a file name if the font file is in the Series' source directory, <v>{title_font}</v> to match the Font used for the title text, or a full path to the font file."
+            },
+            {
+                "name": "Episode Text Font Size",
+                "identifier": "episode_text_font_size",
+                "description": "Size adjustment for the season and episode text",
+                "tooltip": "Number ≥<v>0.0</v>. Default is <v>1.0</v>.",
+                "default": 1.0
+            },
+            {
+                "name": "Episode Text Color",
+                "identifier": "episode_text_color",
+                "description": "Color to use for the episode text",
+                "tooltip": "Defaults to match the Title Color."
+            },
+            {
+                "name": "Episode Stroke Text Color",
+                "identifier": "episode_text_stroke_color",
+                "description": "Color to use for the stroke of the episode text",
+                "tooltip": "Defaults to match the Stroke Text Color."
+            },
+            {
+                "name": "Episode Text Kerning",
+                "identifier": "episode_text_kerning",
+                "description": "Spacing between characters for the episode text",
+                "tooltip": "Default is <v>18</v>. Unit is pixels.",
+                "default": 18
             },
             {
                 "name": "Separator Character",
                 "identifier": "separator",
                 "description": "Character to separate season and episode text",
-                "tooltip": "Default is <v>•</v>."
+                "tooltip": "Default is <v>•</v>.",
+                "default": "•"
             },
             {
                 "name": "Horizontal Alignment",
                 "identifier": "h_align",
                 "description": "Horizontal alignment of text",
-                "tooltip": "Either <v>left</v>, <v>center</v> or <v>right</v>. Default is <v>left</v>."
+                "tooltip": "Either <v>left</v>, <v>center</v>, or <v>right</v>. Default is <v>left</v>.",
+                "default": "left"
             },
             {
                 "name": "CRT TV Overlay",
                 "identifier": "crt_overlay",
                 "description": "CRT TV Overlay Toggle",
-                "tooltip": "Either <v>nobezel</v> or <v>bezel</v>. Default is <v>None</v>."
+                "tooltip": "Whether to display the CRT TV overlay. Either <v>nobezel</v>, or <v>bezel</v>. Default is no overlay."
             },
             {
                 "name": "CRT TV Watched/Unwatched Overlay",
                 "identifier": "crt_state_overlay",
                 "description": "CRT TV Overlay Watched-Status Toggle",
-                "tooltip": "Whether to change the CRT overlay with the watched status of the Episode. Either <v>True</v> or <v>False</v>. Default is <v>False</v>. Will only work if the CRT TV Overlay Toggle is enabled."
+                "tooltip": "Whether to change the CRT overlay with the watched status of the Episode. Either <v>True</v> or <v>False</v>. Default is <v>False</v>. Will only work if the CRT TV Overlay Toggle is enabled.",
+                "default": "False"
             },
             {
                 "name": "Gradient Omission",
                 "identifier": "omit_gradient",
                 "description": "Whether to omit the gradient overlay",
-                "tooltip": "Either <v>True</v> or <v>False</v>. Set to <v>False</v> if you have trouble reading text on brighter images.<br>Default is <v>True</v>."
+                "tooltip": "Either <v>True</v> or <v>False</v>. Set to <v>False</v> if you have trouble reading the text on brighter images. Default is <v>True</v>.",
+                "default": "True"
             }
-        ],        
-        "hash": "f8dd2e3b917b651b9fa5c56609054851"
+        ],
+        "hash": "7b4e4c497c2c47ba3d5f587bb8152b8d"
     },
     {
         "name": "Horizon",
@@ -404,60 +443,99 @@
         "supports_custom_seasons": true,
         "supported_extras": [
             {
-                "name": "Episode Text Vertical Shift",
-                "identifier": "episode_text_vertical_shift",
-                "description": "Vertical Shift for Episode Text",
-                "tooltip": "Additional vertical shift to apply to the season and episode text. Default is <v>0</v>.<br> If multi-line issues, problem fonts may be fixed by fix vertical metrics at <v>https://transfonter.org/</v>."
-            },
-            {
                 "name": "Stroke Text Color",
                 "identifier": "stroke_color",
-                "description": "Color to use for the episode & title text stroke",
-                "tooltip": "Default is <c>black</c>."
+                "description": "Color to use for the text stroke",
+                "tooltip": "Default is <c>black</c>.",
+                "default": "black"
+            },
+            {
+                "name": "Episode Text Vertical Shift",
+                "identifier": "episode_text_vertical_shift",
+                "description": "Vertical shift for episode text",
+                "tooltip": "Additional vertical shift to apply to the season and episode text. If you encounter multi-line issues, problem fonts maybe fixed by Fix vertical metrics at <v>https://transfonter.org/</v>. Default is <v>0</v>. Unit is pixels.",
+                "default": 0
+            },
+            {
+                "name": "Episode Text Font",
+                "identifier": "episode_text_font",
+                "description": "Font to use for the season and episode text",
+                "tooltip": "This can be just a file name if the font file is in the Series' source directory, <v>{title_font}</v> to match the Font used for the title text, or a full path to the font file."
+            },
+            {
+                "name": "Episode Text Font Size",
+                "identifier": "episode_text_font_size",
+                "description": "Size adjustment for the season and episode text",
+                "tooltip": "Number ≥<v>0.0</v>. Default is <v>1.0</v>.",
+                "default": 1.0
+            },
+            {
+                "name": "Episode Text Color",
+                "identifier": "episode_text_color",
+                "description": "Color to use for the episode text",
+                "tooltip": "Defaults to match the Title Color."
+            },
+            {
+                "name": "Episode Stroke Text Color",
+                "identifier": "episode_text_stroke_color",
+                "description": "Color to use for the stroke of the episode text",
+                "tooltip": "Defaults to match the Stroke Text Color."
+            },
+            {
+                "name": "Episode Text Kerning",
+                "identifier": "episode_text_kerning",
+                "description": "Spacing between characters for the episode text",
+                "tooltip": "Default is <v>18</v>. Unit is pixels.",
+                "default": 18
             },
             {
                 "name": "Separator Character",
                 "identifier": "separator",
                 "description": "Character to separate season and episode text",
-                "tooltip": "Default is <v>•</v>."
+                "tooltip": "Default is <v>•</v>.",
+                "default": "•"
             },
             {
                 "name": "Horizontal Alignment",
                 "identifier": "h_align",
-                "description": "Horizontal alignment of the text and symbol",
-                "tooltip": "Either <v>left</v> or <v>right</v>. Default is <v>left</v>."
+                "description": "Horizontal alignment of text",
+                "tooltip": "Either <v>left</v>, <v>center</v>, or <v>right</v>. Default is <v>left</v>.",
+                "default": "left"
             },
             {
                 "name": "Symbol",
                 "identifier": "symbol",
                 "description": "Add a custom symbol behind the text",
-                "tooltip": "Either <v>acolyte</v>, <v>ahsoka</v>, <v>andor</v>, <v>bobafett<v>, <v>mandalorian</v>, <v>obiwan</v>, or <v>witcher</v> to use a built-in symbol, or <v>logo</v> to use the Series logo."
+                "tooltip": "Either <v>acolyte</v>, <v>ahsoka</v>, <v>andor</v>, <v>bobafett<v>, <v>mandalorian</v>, <v>obiwan</v>, or <v>witcher</v> to use a built-in symbol; or <v>logo</v> to use the Series logo."
             },
             {
                 "name": "CRT TV Overlay",
                 "identifier": "crt_overlay",
                 "description": "CRT TV Overlay Toggle",
-                "tooltip": "Either <v>nobezel</v> or <v>bezel</v>. Default is <v>None</v>."
+                "tooltip": "Whether to display the CRT TV overlay. Either <v>nobezel</v>, or <v>bezel</v>. Default is no overlay."
             },
             {
                 "name": "CRT TV Watched/Unwatched Overlay",
                 "identifier": "crt_state_overlay",
                 "description": "CRT TV Overlay Watched-Status Toggle",
-                "tooltip": "Whether to change the CRT overlay with the watched status of the Episode. Either <v>True</v> or <v>False</v>. Default is <v>False</v>. Will only work if the CRT TV Overlay Toggle is enabled."
+                "tooltip": "Whether to change the CRT overlay with the watched status of the Episode. Either <v>True</v> or <v>False</v>. Default is <v>False</v>. Will only work if the CRT TV Overlay Toggle is enabled.",
+                "default": "False"
             },
             {
                 "name": "Gradient Omission",
                 "identifier": "omit_gradient",
                 "description": "Whether to omit the gradient overlay",
-                "tooltip": "Either <v>True</v> or <v>False</v>. Set to <v>False</v> if you have trouble reading text on brighter images. Default is <v>True</v>."
+                "tooltip": "Either <v>True</v> or <v>False</v>. Set to <v>False</v> if you have trouble reading the text on brighter images. Default is <v>True</v>.",
+                "default": "True"
             },
             {
                 "name": "Alignment Overlay",
                 "identifier": "alignment_overlay",
                 "description": "Alignment Overlay Toggle",
-                "tooltip": "Enable an alignment overlay to help assist adjusting offsets for misaligned custom fonts. The overlay has guiding lines every 10 pixels. Either <v>True</v> or <v>False</v>. Default is <v>False</v>."
-            }            
-        ],        
-        "hash": "d3dec2bf026d7266652cd9fd33e72be3"
+                "tooltip": "Enable an alignment overlay to help assist adjusting offsets for misaligned custom fonts. The overlay has guiding lines every 10 pixels. Either <v>True</v> or <v>False</v>. Default is <v>False</v>.",
+                "default": "False"
+            }
+        ],              
+        "hash": "b07175c8b64176bf80fc1cf13bfb59e7"
     }
 ]


### PR DESCRIPTION
Add optional extras to Dawn and Horizon cards to use separate colors for the episode text and stroke
Add extras to Dawn and Horizon cards to use a custom font or title font for episode text and to change episode text font size
Rearranged extras to be inline with each section they change
Add extra to Dawn and Horizon cards to adjust episode text kerning for custom fonts